### PR TITLE
Make TOTP issuer configuration instead showing tenant domain.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -64,6 +64,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String SUPER_TENANT = "carbon.super";
 	public static final String TOTP_AUTHENTICATION_ENDPOINT_URL = "TOTPAuthenticationEndpointURL";
 	public static final String TOTP_ISSUER = "Issuer";
+	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -63,6 +63,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ENABLE_TOTP = "ENABLE_TOTP";
 	public static final String SUPER_TENANT = "carbon.super";
 	public static final String TOTP_AUTHENTICATION_ENDPOINT_URL = "TOTPAuthenticationEndpointURL";
+	public static final String TOTP_ISSUER = "Issuer";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -86,7 +86,7 @@ public class TOTPKeyGenerator {
 					secretKey = decryptedSecretKey;
 				}
 
-				String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain);
+				String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
 				String qrCodeURL =
 						"otpauth://totp/" + issuer + ":" + tenantAwareUsername + "?secret=" +
 						secretKey +

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -85,10 +85,12 @@ public class TOTPKeyGenerator {
 				} else {
 					secretKey = decryptedSecretKey;
 				}
+
+				String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain);
 				String qrCodeURL =
-						"otpauth://totp/" + tenantDomain + ":" + tenantAwareUsername + "?secret=" +
+						"otpauth://totp/" + issuer + ":" + tenantAwareUsername + "?secret=" +
 						secretKey +
-						"&issuer=" + tenantDomain;
+						"&issuer=" + issuer;
 				encodedQRCodeURL = Base64.encodeBase64String(qrCodeURL.getBytes());
 				claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL, encodedQRCodeURL);
 			}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -88,8 +88,16 @@ public class TOTPUtil {
 		return new String(CryptoUtil.getDefaultCryptoUtil().base64DecodeAndDecrypt(cipherText), Charsets.UTF_8);
 	}
 
-	public static String getTOTPIssuerDisplayName(String tenantDomain) {
-		String issuer = getTOTPParameters().get(TOTPAuthenticatorConstants.TOTP_ISSUER);
+	public static String getTOTPIssuerDisplayName(String tenantDomain) throws TOTPException {
+
+		String issuer;
+		if (TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN.equals(tenantDomain) ||
+				Boolean.parseBoolean(getTOTPParameters().get(TOTPAuthenticatorConstants.TOTP_COMMON_ISSUER))) {
+			issuer = getTOTPParameters().get(TOTPAuthenticatorConstants.TOTP_ISSUER);
+		} else {
+			issuer = getIssuerFromRegistry(tenantDomain);
+		}
+
 		if (StringUtils.isBlank(issuer)) {
 			issuer = tenantDomain;
 		}
@@ -165,6 +173,68 @@ public class TOTPUtil {
 		AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance()
 				.getAuthenticatorBean(TOTPAuthenticatorConstants.AUTHENTICATOR_NAME);
 		return authConfig.getParameterMap();
+	}
+
+	/**
+	 * Get xml file data from registry and get the value for Issuer.
+	 *
+	 * @throws TOTPException On error during passing XML content or creating document builder
+	 */
+	private static String getIssuerFromRegistry(String tenantDomain)
+			throws TOTPException {
+
+		String issuer = null;
+		int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
+		try {
+			PrivilegedCarbonContext.startTenantFlow();
+			PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+			privilegedCarbonContext.setTenantId(tenantID);
+			privilegedCarbonContext.setTenantDomain(tenantDomain);
+			Registry registry = (Registry) privilegedCarbonContext.getRegistry(RegistryType.SYSTEM_GOVERNANCE);
+			Resource resource = registry.get(TOTPAuthenticatorConstants.AUTHENTICATOR_NAME + "/" +
+					TOTPAuthenticatorConstants.APPLICATION_AUTHENTICATION_XML);
+			Object content = resource.getContent();
+			String xml = new String((byte[]) content);
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			DocumentBuilder builder = factory.newDocumentBuilder();
+			Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+			NodeList authConfigList = doc.getElementsByTagName("AuthenticatorConfig");
+			for (int authConfigIndex = 0; authConfigIndex < authConfigList.getLength(); authConfigIndex++) {
+				Node authConfigNode = authConfigList.item(authConfigIndex);
+				if (authConfigNode.getNodeType() == Node.ELEMENT_NODE) {
+					Element authConfigElement = (Element) authConfigNode;
+					String AuthConfig = authConfigElement.getAttribute(TOTPAuthenticatorConstants.NAME);
+					if (AuthConfig.equals(TOTPAuthenticatorConstants.AUTHENTICATOR_NAME)) {
+						NodeList AuthConfigChildList = authConfigElement.getChildNodes();
+						for (int j = 0; j < AuthConfigChildList.getLength(); j++) {
+							Node authConfigChildNode = AuthConfigChildList.item(j);
+							if (authConfigChildNode.getNodeType() == Node.ELEMENT_NODE) {
+								Element authConfigChildElement = (Element) authConfigChildNode;
+								String tagAttribute = AuthConfigChildList.item(j).getAttributes()
+										.getNamedItem(TOTPAuthenticatorConstants.NAME).getNodeValue();
+								if (tagAttribute.equals(TOTPAuthenticatorConstants.TOTP_ISSUER)) {
+									issuer = authConfigChildElement.getTextContent();
+								}
+							}
+						}
+						break;
+					}
+				}
+			}
+		} catch (RegistryException e) {
+			//Default to tenant domain name on registry exception.
+			issuer = tenantDomain;
+		} catch (SAXException e) {
+			throw new TOTPException("Error while parsing the content as XML", e);
+		} catch (ParserConfigurationException e) {
+			throw new TOTPException("Error while creating new Document Builder", e);
+		} catch (IOException e) {
+			throw new TOTPException("Error while parsing the content as XML via ByteArrayInputStream", e);
+		} finally {
+			PrivilegedCarbonContext.endTenantFlow();
+		}
+		return issuer;
 	}
 
 	/**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -88,6 +88,14 @@ public class TOTPUtil {
 		return new String(CryptoUtil.getDefaultCryptoUtil().base64DecodeAndDecrypt(cipherText), Charsets.UTF_8);
 	}
 
+	public static String getTOTPIssuerDisplayName(String tenantDomain) {
+		String issuer = getTOTPParameters().get(TOTPAuthenticatorConstants.TOTP_ISSUER);
+		if (StringUtils.isBlank(issuer)) {
+			issuer = tenantDomain;
+		}
+		return issuer;
+	}
+
 	/**
 	 * Get stored encoding method from AuthenticationContext.
 	 *

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -64,7 +65,7 @@ public class TOTPKeyGeneratorTest {
         Map<String, String> claims = new HashMap<>();
         String username = "admin";
         when(TOTPUtil.getUserRealm(anyString())).thenReturn(userRealm);
-        when(TOTPUtil.getTOTPIssuerDisplayName(anyString())).thenReturn("carbon.super");
+        when(TOTPUtil.getTOTPIssuerDisplayName(anyString(), (AuthenticationContext) anyObject())).thenReturn("carbon.super");
         claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, "AnySecretKey");
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.getUserClaimValues(MultitenantUtils.getTenantAwareUsername(username), new String[] {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
@@ -64,6 +64,7 @@ public class TOTPKeyGeneratorTest {
         Map<String, String> claims = new HashMap<>();
         String username = "admin";
         when(TOTPUtil.getUserRealm(anyString())).thenReturn(userRealm);
+        when(TOTPUtil.getTOTPIssuerDisplayName(anyString())).thenReturn("carbon.super");
         claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, "AnySecretKey");
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.getUserClaimValues(MultitenantUtils.getTenantAwareUsername(username), new String[] {


### PR DESCRIPTION
## Purpose
> Make TOTP issuer configuration instead showing tenant domain.


`<Parameter name="Issuer">ISSUER_NAME</Parameter>`

If the following property is true, then the same Issuer will be used in tenants as well.

`<Parameter name="UseCommonIssuer">true</Parameter>`

Configuration can be done in application-authentication.xml as follows

     ` <AuthenticatorConfig name="totp" enabled="true">
            <Parameter name="encodingMethod">Base32</Parameter>
            <Parameter name="timeStepSize">30</Parameter>
            <Parameter name="windowSize">3</Parameter>
            <Parameter name="authenticationMandatory">true</Parameter>
            <Parameter name="enrolUserInAuthenticationFlow">true</Parameter>
            <Parameter name="usecase">local</Parameter>
            <Parameter name="secondaryUserstore">primary</Parameter>
            <Parameter name="TOTPAuthenticationEndpointURL">totpauthenticationendpoint/totp.jsp</Parameter>
            <Parameter name="TOTPAuthenticationEndpointErrorPage">totpauthenticationendpoint/totpError.jsp</Parameter>
            <Parameter name="TOTPAuthenticationEndpointEnableTOTPPage">totpauthenticationendpoint/enableTOTP.jsp</Parameter>
            <Parameter name="redirectToMultiOptionPageOnFailure">false</Parameter>
            <Parameter name="Issuer">ISSUER_NAME</Parameter>
        </AuthenticatorConfig>`