### PR TITLE
Add support for template HTML based email sending in TOTP

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -96,6 +96,11 @@
             <version>1.6.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.event</artifactId>
+            <version>${carbon.identity.event.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -111,12 +116,13 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>org.wso2.carbon.identity.application.authenticator.totp.internal</Private-Package>
                         <Import-Package>
                             org.wso2.carbon.core.utils.*,
                             org.wso2.carbon.core.*,
                             org.osgi.service.*,
                             org.wso2.carbon.registry.core.*,
-                            org.wso2.carbon.utils.*,
+                            org.wso2.carbon.utils.*;resolution:=optional,
                             org.apache.commons.logging.*;version="${commons-logging.osgi.version.range}",
                             org.osgi.framework.*; version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
@@ -125,7 +131,8 @@
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.extension.identity.helper.*;
-                            version="${identity.extension.utils.import.version.range}"
+                            version="${identity.extension.utils.import.version.range}",
+                            org.wso2.carbon.identity.event.*;resolution:=optional;version="${carbon.identity.event.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Export-Package>!org.wso2.carbon.identity.application.authenticator.totp.internal.*,

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -122,7 +122,7 @@
                             org.wso2.carbon.core.*,
                             org.osgi.service.*,
                             org.wso2.carbon.registry.core.*,
-                            org.wso2.carbon.utils.*;resolution:=optional,
+                            org.wso2.carbon.utils.*,
                             org.apache.commons.logging.*;version="${commons-logging.osgi.version.range}",
                             org.osgi.framework.*; version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -122,7 +122,7 @@
                             org.wso2.carbon.core.*,
                             org.osgi.service.*,
                             org.wso2.carbon.registry.core.*,
-                            org.wso2.carbon.utils.*,
+                            org.wso2.carbon.utils.*;resolution:=optional,
                             org.apache.commons.logging.*;version="${commons-logging.osgi.version.range}",
                             org.osgi.framework.*; version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -67,4 +67,8 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
+	public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";
+	public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
+	public static final String EVENT_NAME = "TOTP";
+	public static final String AUTHENTICATED_USER = "authenticatedUser";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -126,9 +126,11 @@ public class TOTPTokenGenerator {
 						secretKeyByteArray = codec64.decode(secretKey);
 					}
 					token = getCode(secretKeyByteArray, getTimeIndex(context));
-
 					// Check whether the authenticator is configured to use the event handler implementation.
 					if (TOTPUtil.isEventHandlerBasedEmailSenderEnabled()) {
+						if (log.isDebugEnabled()) {
+							log.debug("TOTP authenticator configured to use the event handler implementation.");
+						}
 						AuthenticatedUser authenticatedUser = (AuthenticatedUser) context
 								.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
 						triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -129,8 +129,8 @@ public class TOTPTokenGenerator {
 
 					// Check whether the authenticator is configured to use the event handler implementation.
 					if (TOTPUtil.isEventHandlerBasedEmailSenderEnabled()) {
-						AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty
-								(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
+						AuthenticatedUser authenticatedUser = (AuthenticatedUser) context
+								.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
 						triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),
 								authenticatedUser.getUserStoreDomain(), TOTPAuthenticatorConstants.EVENT_NAME,
 								Long.toString(token));

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticator;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -30,6 +31,9 @@ import java.util.Hashtable;
 
 /**
  * @scr.component name="identity.application.authenticator.totp.component" immediate="true"
+ * @scr.reference name="EventMgtService"
+ * interface="org.wso2.carbon.identity.event.services.IdentityEventService" cardinality="1..1"
+ * policy="dynamic" bind="setIdentityEventService" unbind="unsetIdentityEventService"
  * @scr.reference name="config.context.service"
  * interface="org.wso2.carbon.utils.ConfigurationContextService"
  * cardinality="1..1" policy="dynamic" bind="setConfigurationContextService"
@@ -105,5 +109,13 @@ public class TOTPAuthenticatorServiceComponent {
 	 */
 	protected void unsetRealmService(RealmService realmService) {
 		TOTPDataHolder.getInstance().setRealmService(null);
+	}
+
+	protected void unsetIdentityEventService(IdentityEventService eventService) {
+		TOTPDataHolder.getInstance().setIdentityEventService(null);
+	}
+
+	protected void setIdentityEventService(IdentityEventService eventService) {
+		TOTPDataHolder.getInstance().setIdentityEventService(eventService);
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
@@ -112,10 +112,12 @@ public class TOTPAuthenticatorServiceComponent {
 	}
 
 	protected void unsetIdentityEventService(IdentityEventService eventService) {
+
 		TOTPDataHolder.getInstance().setIdentityEventService(null);
 	}
 
 	protected void setIdentityEventService(IdentityEventService eventService) {
+
 		TOTPDataHolder.getInstance().setIdentityEventService(eventService);
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.identity.application.authenticator.totp.internal;
 
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -30,6 +31,7 @@ public class TOTPDataHolder {
 	private static TOTPDataHolder instance = new TOTPDataHolder();
 	private RealmService realmService;
 	private ConfigurationContextService configurationContextService;
+	private IdentityEventService identityEventService;
 
 	/**
 	 * Returns the DataHolder instance.
@@ -76,4 +78,13 @@ public class TOTPDataHolder {
 			ConfigurationContextService configurationContextService) {
 		this.configurationContextService = configurationContextService;
 	}
+
+	public IdentityEventService getIdentityEventService() {
+		return identityEventService;
+	}
+
+	public void setIdentityEventService(IdentityEventService identityEventService) {
+		this.identityEventService = identityEventService;
+	}
+
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
@@ -84,6 +84,7 @@ public class TOTPDataHolder {
 	}
 
 	public void setIdentityEventService(IdentityEventService identityEventService) {
+
 		this.identityEventService = identityEventService;
 	}
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -548,18 +548,11 @@ public class TOTPUtil {
 	 * Get the useEventHandlerBasedEmailSender config value from the application-authentication.xml file.
 	 *
 	 * @return Is Event Handler Based Email Sender Enabled.
-	 * @throws AuthenticationFailedException
 	 */
 	public static boolean isEventHandlerBasedEmailSenderEnabled() {
 
 		String eventHandlerBasedEmailSenderProperty = getTOTPParameters()
 				.get(TOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER);
-		if (eventHandlerBasedEmailSenderProperty != null && Boolean
-				.parseBoolean(eventHandlerBasedEmailSenderProperty)) {
-			return true;
-		} else {
-			return false;
-		}
-
+		return Boolean.parseBoolean(eventHandlerBasedEmailSenderProperty);
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -543,4 +543,17 @@ public class TOTPUtil {
 		}
 		return enableTOTPPage;
 	}
+
+
+	public static boolean isEventHandlerBasedEmailSenderEnabled(){
+
+		String eventHandlerBasedEmailSenderProperty =
+				getTOTPParameters().get(TOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER);
+		if(eventHandlerBasedEmailSenderProperty != null && Boolean.parseBoolean(eventHandlerBasedEmailSenderProperty) ){
+			return true;
+		} else {
+			return false;
+		}
+
+	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -544,12 +544,18 @@ public class TOTPUtil {
 		return enableTOTPPage;
 	}
 
+	/**
+	 * Get the useEventHandlerBasedEmailSender config value from the application-authentication.xml file.
+	 *
+	 * @return Is Event Handler Based Email Sender Enabled.
+	 * @throws AuthenticationFailedException
+	 */
+	public static boolean isEventHandlerBasedEmailSenderEnabled() {
 
-	public static boolean isEventHandlerBasedEmailSenderEnabled(){
-
-		String eventHandlerBasedEmailSenderProperty =
-				getTOTPParameters().get(TOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER);
-		if(eventHandlerBasedEmailSenderProperty != null && Boolean.parseBoolean(eventHandlerBasedEmailSenderProperty) ){
+		String eventHandlerBasedEmailSenderProperty = getTOTPParameters()
+				.get(TOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER);
+		if (eventHandlerBasedEmailSenderProperty != null && Boolean
+				.parseBoolean(eventHandlerBasedEmailSenderProperty)) {
 			return true;
 		} else {
 			return false;

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <identity.extension.utils.import.version.range>[1.0.8, 2.0.0)
         </identity.extension.utils.import.version.range>
         <carbon.identity.event.version>5.13.33</carbon.identity.event.version>
-        <carbon.identity.event.version.range>[5.13.0,6.0.0)</carbon.identity.event.version.range>
+        <carbon.identity.event.version.range>[5.13.0, 6.0.0)</carbon.identity.event.version.range>
         <!--Test Dependencies-->
         <junit.version>4.12</junit.version>
         <testng.version>6.9.10</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,8 @@
         <axis2-transports.version>2.0.0-wso2v21</axis2-transports.version>
         <axis2-transports.version.range>[2.0.0-wso2v21,3.0.0)</axis2-transports.version.range>
         <org.apache.axis2.transport.mail.version.range>[0.0.0,1.0.0)</org.apache.axis2.transport.mail.version.range>
+        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
+        <axis2.wso2.imp.pkg.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.wso2.imp.pkg.version.range>
         <!-- Axiom Version -->
         <axiom.version>1.2.11-wso2v9</axiom.version>
         <axiom.wso2.version>1.2.11.wso2v9</axiom.wso2.version>
@@ -365,6 +367,8 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8, 2.0.0)
         </identity.extension.utils.import.version.range>
+        <carbon.identity.event.version>5.13.33</carbon.identity.event.version>
+        <carbon.identity.event.version.range>[5.13.0,6.0.0)</carbon.identity.event.version.range>
         <!--Test Dependencies-->
         <junit.version>4.12</junit.version>
         <testng.version>6.9.10</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,6 @@
         <axis2-transports.version>2.0.0-wso2v21</axis2-transports.version>
         <axis2-transports.version.range>[2.0.0-wso2v21,3.0.0)</axis2-transports.version.range>
         <org.apache.axis2.transport.mail.version.range>[0.0.0,1.0.0)</org.apache.axis2.transport.mail.version.range>
-        <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
-        <axis2.wso2.imp.pkg.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.wso2.imp.pkg.version.range>
         <!-- Axiom Version -->
         <axiom.version>1.2.11-wso2v9</axiom.version>
         <axiom.wso2.version>1.2.11.wso2v9</axiom.wso2.version>


### PR DESCRIPTION
## Purpose
> Fix wso2/product-is#5839


## Approach
> If Property useEventHandlerBasedEmailSender is configured as true under application-authentication.xml then without using the axis2 based email sending mechanism the totp connector will trigger an event for sending a email. This will use the output-event-adapters to send the email.


## Documentation
> To enable this fix we need to add the following configuration under AuthenticatorConfig "totp"
`<Parameter name="useEventHandlerBasedEmailSender">true</Parameter>`

Add following[1] configuration to email-admin-config.xml
[1] https://docs.google.com/document/d/1Fhj0u-SW0EbofDvP_Pm3zQCAitiaywF2CYrXA02CFUE/edit?usp=sharing