### PR TITLE
Provide capability to enable TOTP only after validating the OTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -35,6 +35,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String AUTHENTICATOR_NAME = "totp";
 	public static final String QR_CODE_CLAIM_URL = "http://wso2.org/claims/identity/qrcodeurl";
 	public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
+	public static final String VERIFY_SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/verifySecretkey";
 	public static final String ENCODING_CLAIM_URL = "http://wso2.org/claims/identity/encoding";
 	public static final String FIRST_NAME_CLAIM_URL = "http://wso2.org/claims/givenname";
 	public static final String BASE32 = "Base32";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -56,7 +56,6 @@ public class TOTPKeyGenerator {
 		String encodedQRCodeURL;
 		String tenantAwareUsername = null;
 		Map<String, String> claims = new HashMap<>();
-		String encoding;
 		try {
 			UserRealm userRealm = TOTPUtil.getUserRealm(username);
 			String tenantDomain = MultitenantUtils.getTenantDomain(username);
@@ -70,11 +69,6 @@ public class TOTPKeyGenerator {
 				if (StringUtils.isEmpty(storedSecretKey) || refresh) {
 					TOTPAuthenticatorKey key = generateKey(tenantDomain, context);
 					generatedSecretKey = key.getKey();
-					if (context == null) {
-						encoding = TOTPUtil.getEncodingMethod(tenantDomain);
-					} else {
-						encoding = TOTPUtil.getEncodingMethod(tenantDomain, context);
-					}
 					claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
 					           TOTPUtil.encrypt(generatedSecretKey));
 				} else {
@@ -87,10 +81,8 @@ public class TOTPKeyGenerator {
 				}
 
 				String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
-				String qrCodeURL =
-						"otpauth://totp/" + issuer + ":" + tenantAwareUsername + "?secret=" +
-						secretKey +
-						"&issuer=" + issuer;
+				String qrCodeURL = "otpauth://totp/" + issuer + ":" + tenantAwareUsername + "?secret=" +
+						secretKey + "&issuer=" + issuer;
 				encodedQRCodeURL = Base64.encodeBase64String(qrCodeURL.getBytes());
 				claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL, encodedQRCodeURL);
 			}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
@@ -117,7 +117,7 @@ public class TOTPAdminService {
 
 				Map<String, String> userClaimValues = userRealm.getUserStoreManager().
 						getUserClaimValues(tenantAwareUsername,
-								new String[] { TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL }, null);
+								new String[]{TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL}, null);
 				encryptedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL);
 
 				if (StringUtils.isBlank(encryptedSecretKey)) {
@@ -132,12 +132,10 @@ public class TOTPAdminService {
 
 				Map<String, String> claims = new HashMap<>();
 				claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, encryptedSecretKey);
+				claims.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL, "");
 				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claims, null);
 
-				Map<String, String> clamsToRemove = new HashMap<>();
-				clamsToRemove.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL, "");
-				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, clamsToRemove, null);
-			}  else {
+			} else {
 				if (log.isDebugEnabled()) {
 					log.debug(
 							"Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
@@ -148,9 +146,9 @@ public class TOTPAdminService {
 			throw new TOTPException(
 					"Failed to access user store manager to store secret key for the user: " + tenantAwareUsername, e);
 		} catch (AuthenticationFailedException e) {
-			throw new TOTPException("Error while retrieving the user realm for the user: " +tenantAwareUsername, e);
+			throw new TOTPException("Error while retrieving the user realm for the user: " + tenantAwareUsername, e);
 		} catch (CryptoException e) {
-			throw new TOTPException("Error while encrypting the secret key for user: " +tenantAwareUsername, e);
+			throw new TOTPException("Error while encrypting the secret key for user: " + tenantAwareUsername, e);
 		}
 
 		return true;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
@@ -80,6 +80,12 @@ public class TOTPAdminService {
 				claimsToPersist.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL,
 						claims.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL));
 				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claimsToPersist, null);
+			} else {
+				if (log.isDebugEnabled()) {
+					log.debug(
+							"Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
+				}
+				throw new TOTPException("Couldn't retrieve the user realm successfully.");
 			}
 		} catch (UserStoreException e) {
 			throw new TOTPException(
@@ -131,6 +137,12 @@ public class TOTPAdminService {
 				Map<String, String> clamsToRemove = new HashMap<>();
 				clamsToRemove.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL, "");
 				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, clamsToRemove, null);
+			}  else {
+				if (log.isDebugEnabled()) {
+					log.debug(
+							"Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
+				}
+				return false;
 			}
 		} catch (UserStoreException e) {
 			throw new TOTPException(

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
@@ -45,232 +45,235 @@ import java.util.Map;
  */
 public class TOTPAdminService {
 
-	private static final Log log = LogFactory.getLog(TOTPAdminService.class);
+    private static final Log log = LogFactory.getLog(TOTPAdminService.class);
 
-	/**
-	 * Generate TOTP Token for a given user.
-	 *
-	 * @param username Username of the user
-	 * @param context  Authentication context
-	 * @return Encoded QR Code URL.
-	 * @throws TOTPException when could not find the user
-	 */
-	public String initTOTP(String username, AuthenticationContext context) throws TOTPException {
+    /**
+     * Generate TOTP Token for a given user.
+     *
+     * @param username Username of the user
+     * @param context  Authentication context
+     * @return Encoded QR Code URL.
+     * @throws TOTPException when could not find the user
+     */
+    public String initTOTP(String username, AuthenticationContext context) throws TOTPException {
 
-		Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false, context);
-		return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
-	}
+        Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false, context);
+        return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
+    }
 
-	/**
-	 * Generate TOTP secret for a given user and will be saved in http://wso2.org/claims/identity/verifySecretkey claim.
-	 *
-	 * @param username Username of the user
-	 * @return Encoded QR Code URL.
-	 * @throws TOTPException
-	 */
-	public String generateSecret(String username) throws TOTPException {
+    /**
+     * Generate TOTP secret for a given user and will be saved in http://wso2.org/claims/identity/verifySecretkey claim.
+     *
+     * @param username Username of the user
+     * @return Encoded QR Code URL.
+     * @throws TOTPException
+     */
+    public String generateSecret(String username) throws TOTPException {
 
-		Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false);
+        Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false);
 
-		String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-		try {
-			UserRealm userRealm = TOTPUtil.getUserRealm(username);
-			if (userRealm != null) {
-				Map<String, String> claimsToPersist = new HashMap<>();
-				claimsToPersist.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL,
-						claims.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL));
-				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claimsToPersist, null);
-			} else {
-				if (log.isDebugEnabled()) {
-					log.debug(
-							"Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
-				}
-				throw new TOTPException("Couldn't retrieve the user realm successfully.");
-			}
-		} catch (UserStoreException e) {
-			throw new TOTPException(
-					"Failed to access user store manager to store secret key for the user: " + tenantAwareUsername, e);
-		} catch (AuthenticationFailedException e) {
-			throw new TOTPException("Error while retrieving the user realm for the user: " + tenantAwareUsername, e);
-		}
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        try {
+            UserRealm userRealm = TOTPUtil.getUserRealm(username);
+            if (userRealm != null) {
+                Map<String, String> claimsToPersist = new HashMap<>();
+                claimsToPersist.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL,
+                        claims.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL));
+                userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claimsToPersist, null);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
+                }
+                throw new TOTPException("Couldn't retrieve the user realm successfully.");
+            }
+        } catch (UserStoreException e) {
+            throw new TOTPException(
+                    "Failed to access user store manager to store secret key for the user: " + tenantAwareUsername, e);
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException("Error while retrieving the user realm for the user: " + tenantAwareUsername, e);
+        }
 
-		return claims.get(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL);
-	}
+        return claims.get(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL);
+    }
 
-	/**
-	 * Enable the TOTP for the given user. OTP will be validated against the secret saved in
-	 * http://wso2.org/claims/identity/verifySecretkey claim and if successful, secret is moved to
-	 * http://wso2.org/claims/identity/secretkey claim.
-	 *
-	 * @param username            Username of the user
-	 * @param verificationCode    verification code generated from the secret issued with {@link #generateSecret(String)}
-	 * @return if TOTP enabling is successful or not.
-	 * @throws TOTPException
-	 */
-	public boolean enableTOTP(String username, int verificationCode) throws TOTPException {
+    /**
+     * Enable the TOTP for the given user. OTP will be validated against the secret saved in
+     * http://wso2.org/claims/identity/verifySecretkey claim and if successful, secret is moved to
+     * http://wso2.org/claims/identity/secretkey claim.
+     *
+     * @param username         Username of the user
+     * @param verificationCode verification code generated from the secret issued with {@link #generateSecret(String)}
+     * @return if TOTP enabling is successful or not.
+     * @throws TOTPException
+     */
+    public boolean enableTOTP(String username, int verificationCode) throws TOTPException {
 
-		String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-		try {
-			UserRealm userRealm = TOTPUtil.getUserRealm(username);
-			if (userRealm != null) {
-				String encryptedSecretKey;
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        try {
+            UserRealm userRealm = TOTPUtil.getUserRealm(username);
+            if (userRealm != null) {
+                String encryptedSecretKey;
 
-				Map<String, String> userClaimValues = userRealm.getUserStoreManager().
-						getUserClaimValues(tenantAwareUsername,
-								new String[]{TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL}, null);
-				encryptedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL);
+                Map<String, String> userClaimValues = userRealm.getUserStoreManager().
+                        getUserClaimValues(tenantAwareUsername,
+                                new String[]{TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL}, null);
+                encryptedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL);
 
-				if (StringUtils.isBlank(encryptedSecretKey)) {
-					throw new TOTPException("Secret key is not generated yet.");
-				}
+                if (StringUtils.isBlank(encryptedSecretKey)) {
+                    throw new TOTPException("Secret key is not generated yet.");
+                }
 
-				boolean validationResult = validateTOTP(username, verificationCode,
-						TOTPUtil.decrypt(encryptedSecretKey), null);
-				if (!validationResult) {
-					return false;
-				}
+                boolean validationResult = validateTOTP(username, verificationCode,
+                        TOTPUtil.decrypt(encryptedSecretKey), null);
+                if (!validationResult) {
+                    return false;
+                }
 
-				Map<String, String> claims = new HashMap<>();
-				claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, encryptedSecretKey);
-				claims.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL, "");
-				userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claims, null);
+                Map<String, String> claims = new HashMap<>();
+                claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, encryptedSecretKey);
+                claims.put(TOTPAuthenticatorConstants.VERIFY_SECRET_KEY_CLAIM_URL, "");
+                userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claims, null);
 
-			} else {
-				if (log.isDebugEnabled()) {
-					log.debug(
-							"Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
-				}
-				return false;
-			}
-		} catch (UserStoreException e) {
-			throw new TOTPException(
-					"Failed to access user store manager to store secret key for the user: " + tenantAwareUsername, e);
-		} catch (AuthenticationFailedException e) {
-			throw new TOTPException("Error while retrieving the user realm for the user: " + tenantAwareUsername, e);
-		} catch (CryptoException e) {
-			throw new TOTPException("Error while encrypting the secret key for user: " + tenantAwareUsername, e);
-		}
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Couldn't retrieve the user realm successfully. User realm is null for user: " + username);
+                }
+                return false;
+            }
+        } catch (UserStoreException e) {
+            throw new TOTPException(
+                    "Failed to access user store manager to store secret key for the user: " + tenantAwareUsername, e);
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException("Error while retrieving the user realm for the user: " + tenantAwareUsername, e);
+        } catch (CryptoException e) {
+            throw new TOTPException("Error while encrypting the secret key for user: " + tenantAwareUsername, e);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	/**
-	 * Resets TOTP credentials of the user.
-	 *
-	 * @param username Username of the user
-	 * @return true, if successfully resets
-	 * @throws TOTPException when could not find the user
-	 */
-	public boolean resetTOTP(String username) throws TOTPException, AuthenticationFailedException {
-		return TOTPKeyGenerator.resetLocal(username);
-	}
+    /**
+     * Resets TOTP credentials of the user.
+     *
+     * @param username Username of the user
+     * @return true, if successfully resets
+     * @throws TOTPException when could not find the user
+     */
+    public boolean resetTOTP(String username) throws TOTPException, AuthenticationFailedException {
 
-	/**
-	 * Refreshes TOTP secret key of the user.
-	 *
-	 * @param username Username of the user
-	 * @param context  Authentication context
-	 * @return Encoded QR Code URL for refreshed secret key
-	 * @throws TOTPException when could not find the user
-	 */
-	public String refreshSecretKey(String username, AuthenticationContext context) throws TOTPException {
-		Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, true, context);
-		return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
-	}
+        return TOTPKeyGenerator.resetLocal(username);
+    }
 
-	/**
-	 * Retrieve the secret key of a given user.
-	 *
-	 * @param username Username of the user
-	 * @param context  Authentication context
-	 * @return Secret Key.
-	 * @throws TOTPException when could not find the user
-	 */
-	public String retrieveSecretKey(String username, AuthenticationContext context) throws TOTPException {
-		UserRealm userRealm;
-		String tenantAwareUsername = null;
-		String secretKey = null;
-		Map<String, String> claims = new HashMap<>();
-		String encoding;
-		try {
-			userRealm = TOTPUtil.getUserRealm(username);
-			String tenantDomain = MultitenantUtils.getTenantDomain(username);
-			tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-			if (userRealm != null) {
-				Map<String, String> userClaimValues = userRealm.getUserStoreManager().
-						getUserClaimValues(tenantAwareUsername,
-								new String[] { TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL }, null);
-				secretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
-				if (StringUtils.isEmpty(secretKey)) {
-					TOTPAuthenticatorKey key = TOTPKeyGenerator.generateKey(tenantDomain, context);
-					secretKey = key.getKey();
-					if (context == null) {
-						encoding = TOTPUtil.getEncodingMethod(tenantDomain);
-					} else {
-						encoding = TOTPUtil.getEncodingMethod(tenantDomain, context);
-					}
-					claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, TOTPUtil.encrypt(secretKey));
-					claims.put(TOTPAuthenticatorConstants.ENCODING_CLAIM_URL, encoding);
-					TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
-				} else {
-					secretKey = TOTPUtil.decrypt(secretKey);
-				}
-			}
-		} catch (AuthenticationFailedException e) {
-			throw new TOTPException("TOTPAdminService cannot find the property value for encoding method", e);
-		} catch (UserStoreException e) {
-			throw new TOTPException(
-					"TOTPAdminService failed while trying to get the user store manager from user realm of the user : "
-							+ tenantAwareUsername, e);
-		} catch (CryptoException e) {
-			throw new TOTPException("TOTPAdminService failed while decrypt the stored SecretKey ", e);
-		}
-		return secretKey;
-	}
+    /**
+     * Refreshes TOTP secret key of the user.
+     *
+     * @param username Username of the user
+     * @param context  Authentication context
+     * @return Encoded QR Code URL for refreshed secret key
+     * @throws TOTPException when could not find the user
+     */
+    public String refreshSecretKey(String username, AuthenticationContext context) throws TOTPException {
 
-	/**
-	 * Validates the user entered verification code.
-	 *
-	 * @param username         Username of the user.
-	 * @param context          Authentication context.
-	 * @param verificationCode OTP verification code.
-	 * @return whether OTP is valid or not.
-	 * @throws TOTPException when could not find the user.
-	 */
-	public boolean validateTOTP(String username, AuthenticationContext context, int verificationCode) throws
-			TOTPException {
+        Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, true, context);
+        return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
+    }
 
-		String secretKey = retrieveSecretKey(username, context);
+    /**
+     * Retrieve the secret key of a given user.
+     *
+     * @param username Username of the user
+     * @param context  Authentication context
+     * @return Secret Key.
+     * @throws TOTPException when could not find the user
+     */
+    public String retrieveSecretKey(String username, AuthenticationContext context) throws TOTPException {
 
-		return validateTOTP(username, verificationCode, secretKey, context);
-	}
+        UserRealm userRealm;
+        String tenantAwareUsername = null;
+        String secretKey = null;
+        Map<String, String> claims = new HashMap<>();
+        String encoding;
+        try {
+            userRealm = TOTPUtil.getUserRealm(username);
+            String tenantDomain = MultitenantUtils.getTenantDomain(username);
+            tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+            if (userRealm != null) {
+                Map<String, String> userClaimValues = userRealm.getUserStoreManager().
+                        getUserClaimValues(tenantAwareUsername,
+                                new String[]{TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
+                secretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+                if (StringUtils.isEmpty(secretKey)) {
+                    TOTPAuthenticatorKey key = TOTPKeyGenerator.generateKey(tenantDomain, context);
+                    secretKey = key.getKey();
+                    if (context == null) {
+                        encoding = TOTPUtil.getEncodingMethod(tenantDomain);
+                    } else {
+                        encoding = TOTPUtil.getEncodingMethod(tenantDomain, context);
+                    }
+                    claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, TOTPUtil.encrypt(secretKey));
+                    claims.put(TOTPAuthenticatorConstants.ENCODING_CLAIM_URL, encoding);
+                    TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
+                } else {
+                    secretKey = TOTPUtil.decrypt(secretKey);
+                }
+            }
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException("TOTPAdminService cannot find the property value for encoding method", e);
+        } catch (UserStoreException e) {
+            throw new TOTPException(
+                    "TOTPAdminService failed while trying to get the user store manager from user realm of the user : "
+                            + tenantAwareUsername, e);
+        } catch (CryptoException e) {
+            throw new TOTPException("TOTPAdminService failed while decrypt the stored SecretKey ", e);
+        }
+        return secretKey;
+    }
 
-	private boolean validateTOTP(String username, int verificationCode, String secretKey, AuthenticationContext context)
-			throws TOTPException {
+    /**
+     * Validates the user entered verification code.
+     *
+     * @param username         Username of the user.
+     * @param context          Authentication context.
+     * @param verificationCode OTP verification code.
+     * @return whether OTP is valid or not.
+     * @throws TOTPException when could not find the user.
+     */
+    public boolean validateTOTP(String username, AuthenticationContext context, int verificationCode) throws
+            TOTPException {
 
-		TOTPKeyRepresentation encoding = TOTPKeyRepresentation.BASE32;
-		String tenantDomain = MultitenantUtils.getTenantDomain(username);
-		String encodingMethod;
-		try {
-			if (context == null) {
-				encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain);
-			} else {
-				encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain, context);
-			}
-			if (TOTPAuthenticatorConstants.BASE64.equals(encodingMethod)) {
-				encoding = TOTPKeyRepresentation.BASE64;
-			}
-			TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder configBuilder =
-					new TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder()
-							.setKeyRepresentation(encoding);
-			TOTPAuthenticatorCredentials totpAuthenticator =
-					new TOTPAuthenticatorCredentials(configBuilder.build());
-			if (log.isDebugEnabled()) {
-				log.debug("Validating TOTP verification code for the user: " + username);
-			}
-			return totpAuthenticator.authorize(secretKey, verificationCode);
-		} catch (AuthenticationFailedException e) {
-			throw new TOTPException("TOTPTokenVerifier cannot find the property value for encodingMethod.", e);
-		}
-	}
+        String secretKey = retrieveSecretKey(username, context);
+
+        return validateTOTP(username, verificationCode, secretKey, context);
+    }
+
+    private boolean validateTOTP(String username, int verificationCode, String secretKey, AuthenticationContext context)
+            throws TOTPException {
+
+        TOTPKeyRepresentation encoding = TOTPKeyRepresentation.BASE32;
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        String encodingMethod;
+        try {
+            if (context == null) {
+                encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain);
+            } else {
+                encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain, context);
+            }
+            if (TOTPAuthenticatorConstants.BASE64.equals(encodingMethod)) {
+                encoding = TOTPKeyRepresentation.BASE64;
+            }
+            TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder configBuilder =
+                    new TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder()
+                            .setKeyRepresentation(encoding);
+            TOTPAuthenticatorCredentials totpAuthenticator =
+                    new TOTPAuthenticatorCredentials(configBuilder.build());
+            if (log.isDebugEnabled()) {
+                log.debug("Validating TOTP verification code for the user: " + username);
+            }
+            return totpAuthenticator.authorize(secretKey, verificationCode);
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException("TOTPTokenVerifier cannot find the property value for encodingMethod.", e);
+        }
+    }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -221,8 +221,8 @@ public class TOTPAuthenticatorTest {
         when(TOTPTokenGenerator.generateTOTPTokenLocal(username, new AuthenticationContext())).thenReturn("123456");
         AuthenticationContext authenticationContext = new AuthenticationContext();
         authenticationContext.setProperty("username", username);
-        Assert.assertEquals(Whitebox.invokeMethod(totpAuthenticator, "generateTOTPToken",
-                authenticationContext), true);
+        Assert.assertTrue(Whitebox.invokeMethod(totpAuthenticator, "generateTOTPToken",
+                authenticationContext));
     }
 
     @Test(description = "Test case for successful logout request.")

--- a/pom.xml
+++ b/pom.xml
@@ -421,8 +421,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/7946

This PR will provide 2 additional methods to the TOTPAdminService.

1. generateSecret which will accept the user name. This will generate TOTP secret for a given user and will be saved in http://wso2.org/claims/identity/verifySecretkey claim.
2. enableTOTP which will accept username and verification code. This will validate the verification code against the secret saved in http://wso2.org/claims/identity/verifySecretkey claim and if successful, secret is moved to http://wso2.org/claims/identity/secretkey claim upon successful verification.

For these 2 APIs to work, http://wso2.org/claims/identity/verifySecretkey claim needs to be added.