### PR TITLE
Support account locking for TOTP

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -43,6 +43,10 @@
             <version>${identity.extension.utils}</version>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>${log4j.version}</version>
@@ -133,6 +137,10 @@
                             org.wso2.carbon.extension.identity.helper.*;
                             version="${identity.extension.utils.import.version.range}",
                             org.wso2.carbon.identity.event.*;resolution:=optional;version="${carbon.identity.event.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.exception;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Export-Package>!org.wso2.carbon.identity.application.authenticator.totp.internal.*,

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authenticator.totp;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.owasp.encoder.Encode;
@@ -40,9 +41,12 @@ import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenti
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorCredentials;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPKeyRepresentation;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -284,6 +288,21 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			throws AuthenticationFailedException {
 		String token = request.getParameter(TOTPAuthenticatorConstants.TOKEN);
 		String username = context.getProperty("username").toString();
+		AuthenticatedUser authenticatedUserObject =
+				(AuthenticatedUser) context.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
+		String tenantDomain = MultitenantUtils.getTenantDomain(username);
+		String userStoreDomain = UserCoreUtil.extractDomainFromName(username);
+		boolean isLocalUser = TOTPUtil.isLocalUser(context);
+		if (isLocalUser &&
+				TOTPUtil.isAccountLocked(authenticatedUserObject.getUserName(), tenantDomain, userStoreDomain)) {
+			String errorMessage =
+					String.format("Authentication failed since authenticated user: %s, account is locked.",
+							getUserStoreAppendedName(username));
+			if (log.isDebugEnabled()) {
+				log.debug(errorMessage);
+			}
+			throw new AuthenticationFailedException(errorMessage);
+		}
 		if (context.getProperty(TOTPAuthenticatorConstants.ENABLE_TOTP) != null && Boolean
 				.valueOf(context.getProperty(TOTPAuthenticatorConstants.ENABLE_TOTP).toString())) {
 			//adds the claims to the profile if the user enrol and continued.
@@ -306,6 +325,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			try {
 				int tokenValue = Integer.parseInt(token);
 				if (!isValidTokenLocalUser(tokenValue, username, context)) {
+					handleTotpVerificationFail(context);
 					throw new AuthenticationFailedException(
 							"Authentication failed, user :  " + username);
 				}
@@ -320,11 +340,15 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 				} else {
 					context.setSubject(AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username));
 				}
-			} catch (TOTPException | NumberFormatException e) {
-				throw new AuthenticationFailedException(
-						"TOTP Authentication process failed for user " + username, e);
+			} catch (NumberFormatException e) {
+				handleTotpVerificationFail(context);
+				throw new AuthenticationFailedException("TOTP Authentication process failed for user " + username, e);
+			} catch (TOTPException e) {
+				throw new AuthenticationFailedException("TOTP Authentication process failed for user " + username, e);
 			}
 		}
+		// It reached here means the authentication was successful.
+		resetTotpFailedAttempts(context);
 	}
 
 	/**
@@ -478,6 +502,184 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		} catch (AuthenticationFailedException e) {
 			throw new TOTPException(
 					"TOTPTokenVerifier cannot find the property value for encodingMethod");
+		}
+	}
+
+	/**
+	 * Execute account lock flow for TOTP verification failures.
+	 *
+	 * @param context Authentication context.
+	 * @throws AuthenticationFailedException Exception on authentication failure.
+	 */
+	private void handleTotpVerificationFail(AuthenticationContext context) throws AuthenticationFailedException {
+		
+		AuthenticatedUser authenticatedUser =
+				(AuthenticatedUser) context.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
+		/*
+		Account locking is not done for federated flows.
+		Check whether account locking enabled for TOTP to keep backward compatibility.
+		No need to continue if the account is already locked.
+		 */
+		if (!TOTPUtil.isLocalUser(context) || !TOTPUtil.isAccountLockingEnabledForTotp() ||
+				TOTPUtil.isAccountLocked(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),
+						authenticatedUser.getUserStoreDomain())) {
+			return;
+		}
+		int maxAttempts = 0;
+		long unlockTimePropertyValue = 0;
+		double unlockTimeRatio = 1;
+
+		Property[] connectorConfigs = TOTPUtil.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
+		for (Property connectorConfig : connectorConfigs) {
+			switch (connectorConfig.getName()) {
+				case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+					if (!Boolean.parseBoolean(connectorConfig.getValue())) {
+						return;
+					}
+				case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+					if (NumberUtils.isNumber(connectorConfig.getValue())) {
+						maxAttempts = Integer.parseInt(connectorConfig.getValue());
+					}
+					break;
+				case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_TIME:
+					if (NumberUtils.isNumber(connectorConfig.getValue())) {
+						unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
+					}
+					break;
+				case TOTPAuthenticatorConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+					if (NumberUtils.isNumber(connectorConfig.getValue())) {
+						double value = Double.parseDouble(connectorConfig.getValue());
+						if (value > 0) {
+							unlockTimeRatio = value;
+						}
+					}
+					break;
+			}
+		}
+		String username = context.getProperty("username").toString();
+		Map<String, String> claimValues = getUserClaimValues(authenticatedUser, username);
+		if (claimValues == null) {
+			claimValues = new HashMap<>();
+		}
+		int currentAttempts = 0;
+		if (NumberUtils.isNumber(claimValues.get(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM))) {
+			currentAttempts = Integer.parseInt(claimValues.get(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM));
+		}
+		int failedLoginLockoutCountValue = 0;
+		if (NumberUtils.isNumber(claimValues.get(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
+			failedLoginLockoutCountValue =
+					Integer.parseInt(claimValues.get(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
+		}
+
+		Map<String, String> updatedClaims = new HashMap<>();
+		if ((currentAttempts + 1) >= maxAttempts) {
+			// Calculate the incremental unlock-time-interval in milli seconds.
+			unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+					failedLoginLockoutCountValue));
+			// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
+			long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+			updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
+			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+			updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+					String.valueOf(failedLoginLockoutCountValue + 1));
+			IdentityUtil.threadLocalProperties.get().put(TOTPAuthenticatorConstants.ADMIN_INITIATED, false);
+			setUserClaimValues(authenticatedUser, username, updatedClaims);
+			String errorMessage = String.format("User account: %s is locked.", authenticatedUser.getUserName());
+			throw new AuthenticationFailedException(errorMessage);
+		} else {
+			updatedClaims
+					.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
+			setUserClaimValues(authenticatedUser, username, updatedClaims);
+		}
+	}
+
+	private void resetTotpFailedAttempts(AuthenticationContext context) throws AuthenticationFailedException {
+
+		/*
+		Check whether account locking enabled for TOTP to keep backward compatibility.
+		Account locking is not done for federated flows.
+		 */
+		if (!TOTPUtil.isLocalUser(context) || !TOTPUtil.isAccountLockingEnabledForTotp()) {
+			return;
+		}
+		AuthenticatedUser authenticatedUser =
+				(AuthenticatedUser) context.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
+		Property[] connectorConfigs = TOTPUtil.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
+
+		// Return if account lock handler is not enabled.
+		for (Property connectorConfig : connectorConfigs) {
+			if ((TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
+					!Boolean.parseBoolean(connectorConfig.getValue())) {
+				return;
+			}
+		}
+
+		String username = context.getProperty("username").toString();
+		String usernameWithDomain = IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+				authenticatedUser.getUserStoreDomain());
+		try {
+			UserRealm userRealm = TOTPUtil.getUserRealm(username);
+			UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+
+			// Avoid updating the claims if they are already zero.
+			String[] claimsToCheck = {TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM,
+					TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM};
+			Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
+					UserCoreConstants.DEFAULT_PROFILE);
+			String failedSmsOtpAttempts = userClaims.get(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM);
+			String failedLoginLockoutCount =
+					userClaims.get(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
+
+			if (NumberUtils.isNumber(failedSmsOtpAttempts) && Integer.parseInt(failedSmsOtpAttempts) > 0 ||
+					NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+				Map<String, String> updatedClaims = new HashMap<>();
+				updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
+				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+				userStoreManager
+						.setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+			}
+		} catch (UserStoreException e) {
+			log.error("Error while resetting failed SMS OTP attempts", e);
+			String errorMessage =
+					String.format("Failed to reset failed attempts count for user : %s.", authenticatedUser);
+			throw new AuthenticationFailedException(errorMessage, e);
+		}
+	}
+
+	private Map<String, String> getUserClaimValues(AuthenticatedUser authenticatedUser, String username)
+			throws AuthenticationFailedException {
+
+		Map<String, String> claimValues;
+		try {
+			UserRealm userRealm = TOTPUtil.getUserRealm(username);
+			UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+			claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
+					authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+							TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM,
+							TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
+					UserCoreConstants.DEFAULT_PROFILE);
+		} catch (UserStoreException e) {
+			log.error("Error while reading user claims", e);
+			String errorMessage = String.format("Failed to read user claims for user : %s.", authenticatedUser);
+			throw new AuthenticationFailedException(errorMessage, e);
+		}
+		return claimValues;
+	}
+
+	private void setUserClaimValues(AuthenticatedUser authenticatedUser, String username,
+									Map<String, String> updatedClaims)
+			throws AuthenticationFailedException {
+
+		try {
+			UserRealm userRealm = TOTPUtil.getUserRealm(username);
+			UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+			userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+					authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+		} catch (UserStoreException e) {
+			log.error("Error while updating user claims", e);
+			String errorMessage = String.format("Failed to update user claims for user : %s.", authenticatedUser);
+			throw new AuthenticationFailedException(errorMessage, e);
 		}
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -38,6 +38,11 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String VERIFY_SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/verifySecretkey";
 	public static final String ENCODING_CLAIM_URL = "http://wso2.org/claims/identity/encoding";
 	public static final String FIRST_NAME_CLAIM_URL = "http://wso2.org/claims/givenname";
+	public static final String TOTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedTotpAttempts";
+	public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
+			"http://wso2.org/claims/identity/failedLoginLockoutCount";
+	public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+	public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
 	public static final String BASE32 = "Base32";
 	public static final String BASE64 = "Base64";
 	public static final String APPLICATION_AUTHENTICATION_XML = "application-authentication.xml";
@@ -72,4 +77,11 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
 	public static final String EVENT_NAME = "TOTP";
 	public static final String AUTHENTICATED_USER = "authenticatedUser";
+	public static final String LOCAL_AUTHENTICATOR = "LOCAL";
+	public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+	public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
+	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
+	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+	public static final String ADMIN_INITIATED = "AdminInitiated";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
@@ -24,6 +24,8 @@ import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -40,6 +42,12 @@ import java.util.Hashtable;
  * unbind="unsetConfigurationContextService"
  * @scr.reference name="user.realmservice.default" interface="org.wso2.carbon.user.core.service.RealmService"
  * cardinality="1..1" policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ * @scr.reference name="IdentityGovernanceService"
+ * interface="org.wso2.carbon.identity.governance.IdentityGovernanceService"
+ * cardinality="1..1" policy="dynamic" bind="setIdentityGovernanceService" unbind="unsetIdentityGovernanceService"
+ * @scr.reference name="AccountLockService"
+ * interface="org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService" unbind="unsetAccountLockService"
  */
 public class TOTPAuthenticatorServiceComponent {
 
@@ -119,5 +127,25 @@ public class TOTPAuthenticatorServiceComponent {
 	protected void setIdentityEventService(IdentityEventService eventService) {
 
 		TOTPDataHolder.getInstance().setIdentityEventService(eventService);
+	}
+
+	protected void setIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+		TOTPDataHolder.getInstance().setIdentityGovernanceService(idpManager);
+	}
+
+	protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+		TOTPDataHolder.getInstance().setIdentityGovernanceService(null);
+	}
+
+	protected void setAccountLockService(AccountLockService accountLockService) {
+
+		TOTPDataHolder.getInstance().setAccountLockService(accountLockService);
+	}
+
+	protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+		TOTPDataHolder.getInstance().setAccountLockService(null);
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.application.authenticator.totp.internal;
 
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -32,6 +34,8 @@ public class TOTPDataHolder {
 	private RealmService realmService;
 	private ConfigurationContextService configurationContextService;
 	private IdentityEventService identityEventService;
+	private AccountLockService accountLockService;
+	private IdentityGovernanceService identityGovernanceService;
 
 	/**
 	 * Returns the DataHolder instance.
@@ -87,6 +91,49 @@ public class TOTPDataHolder {
 	public void setIdentityEventService(IdentityEventService identityEventService) {
 
 		this.identityEventService = identityEventService;
+	}
+
+	/**
+	 * Get the IdentityGovernance service.
+	 *
+	 * @return IdentityGovernance service.
+	 */
+	public IdentityGovernanceService getIdentityGovernanceService() {
+
+		if (identityGovernanceService == null) {
+			throw new RuntimeException("IdentityGovernanceService not available. Component is not started properly.");
+		}
+		return identityGovernanceService;
+	}
+
+	/**
+	 * Set the IdentityGovernance service.
+	 *
+	 * @param identityGovernanceService The IdentityGovernance service.
+	 */
+	public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+		this.identityGovernanceService = identityGovernanceService;
+	}
+
+	/**
+	 * Get the AccountLock service.
+	 *
+	 * @return AccountLock service.
+	 */
+	public AccountLockService getAccountLockService() {
+
+		return accountLockService;
+	}
+
+	/**
+	 * Set the AccountLock service.
+	 *
+	 * @param accountLockService The AccountLock service.
+	 */
+	public void setAccountLockService(AccountLockService accountLockService) {
+
+		this.accountLockService = accountLockService;
 	}
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -44,6 +44,8 @@ import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPExc
 import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -578,7 +580,7 @@ public class TOTPUtil {
 									TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_TIME,
 									TOTPAuthenticatorConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO
 							}, tenantDomain);
-		} catch (Exception e) {
+		} catch (IdentityGovernanceException e) {
 			throw new AuthenticationFailedException(
 					"Error occurred while retrieving account lock connector configuration", e);
 		}
@@ -611,7 +613,7 @@ public class TOTPUtil {
 		try {
 			return TOTPDataHolder.getInstance().getAccountLockService()
 					.isAccountLocked(userName, tenantDomain, userStoreDomain);
-		} catch (Exception e) {
+		} catch (AccountLockServiceException e) {
 			throw new AuthenticationFailedException(
 					String.format("Error while validating account lock status of user: %s.", userName), e);
 		}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -559,7 +559,7 @@ public class TOTPUtil {
 	}
 
 	/**
-	 *  Get Account Lock Connector Configs.
+	 * Get Account Lock Connector Configs.
 	 *
 	 * @param tenantDomain Tenant domain.
 	 * @return Account Lock Connector Configs.
@@ -596,6 +596,15 @@ public class TOTPUtil {
 				getTOTPParameters().get(TOTPAuthenticatorConstants.ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS));
 	}
 
+	/**
+	 * Check whether the user account is locked.
+	 *
+	 * @param userName        The username of the user.
+	 * @param tenantDomain    The tenant domain.
+	 * @param userStoreDomain The userstore domain.
+	 * @return True if the account is locked.
+	 * @throws AuthenticationFailedException Exception on authentication failure.
+	 */
 	public static boolean isAccountLocked(String userName, String tenantDomain, String userStoreDomain)
 			throws AuthenticationFailedException {
 
@@ -617,13 +626,11 @@ public class TOTPUtil {
 	public static boolean isLocalUser(AuthenticationContext context) {
 
 		Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
-		if(stepConfigMap != null) {
+		if (stepConfigMap != null) {
 			for (StepConfig stepConfig : stepConfigMap.values()) {
-				if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep()) {
-					if (stepConfig.getAuthenticatedIdP().equals(TOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR)) {
-						return true;
-					}
-					break;
+				if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep() && StringUtils
+						.equals(TOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR, stepConfig.getAuthenticatedIdP())) {
+					return true;
 				}
 			}
 		}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -36,11 +36,13 @@ import org.wso2.carbon.extension.identity.helper.util.IdentityHelperUtil;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
@@ -554,5 +556,77 @@ public class TOTPUtil {
 		String eventHandlerBasedEmailSenderProperty = getTOTPParameters()
 				.get(TOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER);
 		return Boolean.parseBoolean(eventHandlerBasedEmailSenderProperty);
+	}
+
+	/**
+	 *  Get Account Lock Connector Configs.
+	 *
+	 * @param tenantDomain Tenant domain.
+	 * @return Account Lock Connector Configs.
+	 * @throws AuthenticationFailedException Exception on authentication failure.
+	 */
+	public static Property[] getAccountLockConnectorConfigs(String tenantDomain) throws AuthenticationFailedException {
+
+		Property[] connectorConfigs;
+		try {
+			connectorConfigs = TOTPDataHolder.getInstance()
+					.getIdentityGovernanceService()
+					.getConfiguration(
+							new String[]{
+									TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE,
+									TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX,
+									TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_TIME,
+									TOTPAuthenticatorConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO
+							}, tenantDomain);
+		} catch (Exception e) {
+			throw new AuthenticationFailedException(
+					"Error occurred while retrieving account lock connector configuration", e);
+		}
+		return connectorConfigs;
+	}
+
+	/**
+	 * Check whether account locking is enabled for TOTP.
+	 *
+	 * @return True if account locking is enabled for TOTP.
+	 */
+	public static boolean isAccountLockingEnabledForTotp() {
+
+		return Boolean.parseBoolean(
+				getTOTPParameters().get(TOTPAuthenticatorConstants.ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS));
+	}
+
+	public static boolean isAccountLocked(String userName, String tenantDomain, String userStoreDomain)
+			throws AuthenticationFailedException {
+
+		try {
+			return TOTPDataHolder.getInstance().getAccountLockService()
+					.isAccountLocked(userName, tenantDomain, userStoreDomain);
+		} catch (Exception e) {
+			throw new AuthenticationFailedException(
+					String.format("Error while validating account lock status of user: %s.", userName), e);
+		}
+	}
+
+	/**
+	 * Check whether the user being authenticated via a local authenticator or not.
+	 *
+	 * @param context Authentication context.
+	 * @return Whether the user being authenticated via a local authenticator.
+	 */
+	public static boolean isLocalUser(AuthenticationContext context) {
+
+		Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+		if(stepConfigMap != null) {
+			for (StepConfig stepConfig : stepConfigMap.values()) {
+				if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep()) {
+					if (stepConfig.getAuthenticatedIdP().equals(TOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR)) {
+						return true;
+					}
+					break;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
                 <artifactId>org.wso2.carbon.identity.mgt</artifactId>
                 <version>${carbon.identity.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${carbon.identity.account.lock.handler.version}</version>
+            </dependency>
             <!--Test Dependencies-->
             <dependency>
                 <groupId>junit</groupId>
@@ -179,6 +184,9 @@
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>
+        <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
         <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
         <!--Carbon component version-->
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
Support account locking for TOTP

Similar behaviour in wso2-extensions/identity-outbound-auth-sms-otp#91 and wso2-extensions/identity-outbound-auth-email-otp#79