### PR TITLE
Add externalized URLs (Phase 1) in tenant qualified mode 

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
         <artifactId>identity-outbound-auth-totp</artifactId>
-        <version>2.2.8-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
         <artifactId>identity-outbound-auth-totp</artifactId>
-        <version>2.2.8-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.totp.feature</artifactId>
-    <version>2.2.8-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - identity TOTP Feature</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
     <artifactId>identity-outbound-auth-totp</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.8-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>WSO2 Carbon Extension - Platform Aggregator Pom</name>
     <url>http://wso2.org</url>
     <parent>


### PR DESCRIPTION
## Purpose
Support externalized/customized web app URLs (hosted within IS) in tenant qualified mode
Part of https://github.com/wso2/product-is/issues/10953

- Doing a major version bump since the changes introduced are backward-incompatible


With this change, we can define a custom context path (relative and hosted within IS) in the tenant qualified URL mode
eg:

```
[authentication.authenticator.totp.parameters]
TOTPAuthenticationEndpointURL="authenticationendpoint/totp.do"
TOTPAuthenticationEndpointErrorPage="authenticationendpoint/totp_error.do"
TOTPAuthenticationEndpointEnableTOTPPage="authenticationendpoint/totp_enroll.do"
```
