### PR TITLE
Move TOTP pages to login portal

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -53,9 +53,9 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String EMAIL_CLAIM_URL = "http://wso2.org/claims/emailaddress";
 	public static final String LOGIN_PAGE = "authenticationendpoint/login.do";
 
-	public static final String TOTP_LOGIN_PAGE = "totpauthenticationendpoint/totp.jsp";
-	public static final String ERROR_PAGE = "totpauthenticationendpoint/totpError.jsp";
-	public static final String ENABLE_TOTP_REQUEST_PAGE = "totpauthenticationendpoint/enableTOTP.jsp";
+	public static final String TOTP_LOGIN_PAGE = "authenticationendpoint/totp.do";
+	public static final String ERROR_PAGE = "authenticationendpoint/totp_error.do";
+	public static final String ENABLE_TOTP_REQUEST_PAGE = "authenticationendpoint/totp_enroll.do";
 
 	public static final String TOKEN = "token";
 	public static final String SEND_TOKEN = "sendToken";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -529,7 +529,7 @@ public class TOTPAuthenticatorTest {
         verify(httpServletResponse).sendRedirect(captor.capture());
 
         // Assert everything related to the error scenario.
-        Assert.assertTrue(captor.getValue().contains("totpError.jsp"));
+        Assert.assertTrue(captor.getValue().contains("totp_error.do"));
         Assert.assertTrue(captor.getValue().contains("sessionDataKey=" + context.getContextIdentifier()));
         Assert.assertTrue(captor.getValue().contains("authenticators=totp"));
         Assert.assertTrue(captor.getValue().contains("type=totp_error"));

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtilTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtilTest.java
@@ -18,7 +18,6 @@
  */
 package org.wso2.carbon.identity.application.authenticator.totp.util;
 
-import org.apache.commons.lang.StringUtils;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -60,7 +59,6 @@ import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.testng.Assert.assertEquals;
-import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ENABLE_TOTP_REQUEST_PAGE;
 
 @PrepareForTest({FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, ConfigurationFacade.class,
         IdentityTenantUtil.class, ServiceURLBuilder.class})
@@ -446,16 +444,16 @@ public class TOTPUtilTest {
         return new Object[][]{
                 {"carbon.super",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/enableTOTP.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_enroll.do"},
                 {"carbon.super",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/enableTOTP.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_enroll.do"},
                 {"wso2.com",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/enableTOTP.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_enroll.do"},
                 {"wso2.com",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/t/wso2.com/totpauthenticationendpoint/enableTOTP.jsp"},
+                        "https://localhost:9443/t/wso2.com/authenticationendpoint/totp_enroll.do"},
         };
     }
 
@@ -480,16 +478,16 @@ public class TOTPUtilTest {
         return new Object[][]{
                 {"carbon.super",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totp.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp.do"},
                 {"carbon.super",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totp.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp.do"},
                 {"wso2.com",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totp.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp.do"},
                 {"wso2.com",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/t/wso2.com/totpauthenticationendpoint/totp.jsp"},
+                        "https://localhost:9443/t/wso2.com/authenticationendpoint/totp.do"},
         };
     }
 
@@ -514,16 +512,16 @@ public class TOTPUtilTest {
         return new Object[][]{
                 {"carbon.super",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totpError.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_error.do"},
                 {"carbon.super",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totpError.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_error.do"},
                 {"wso2.com",
                         "https://localhost:9443/authenticationendpoint/login.do",
-                        "https://localhost:9443/totpauthenticationendpoint/totpError.jsp"},
+                        "https://localhost:9443/authenticationendpoint/totp_error.do"},
                 {"wso2.com",
                         "authenticationendpoint/login.do",
-                        "https://localhost:9443/t/wso2.com/totpauthenticationendpoint/totpError.jsp"},
+                        "https://localhost:9443/t/wso2.com/authenticationendpoint/totp_error.do"},
         };
     }
 

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -15,19 +15,20 @@
  ~ limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
         <artifactId>identity-outbound-auth-totp</artifactId>
         <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>org.wso2.carbon.extension.identity.authenticator.totp.feature</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - identity TOTP Feature</name>
     <url>http://wso2.org</url>
     <description>This feature contains extension feature for totp</description>
+
     <dependencies>
         <dependency>
             <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
@@ -35,6 +36,7 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -62,6 +64,12 @@
                                     org.wso2.carbon.extension.identity.authenticator.outbound.totp:org.wso2.carbon.extension.identity.authenticator.totp.connector
                                 </bundleDef>
                             </bundles>
+                            <importFeatures>
+                                <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.identity.core.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.extension.identity.helper:compatible:${identity.extension.utils}</importFeatureDef>
+                            </importFeatures>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,21 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
+                <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
+                <version>${identity.extension.utils}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!--Test Dependencies-->
             <dependency>


### PR DESCRIPTION
## Purpose
Depends on changes done in https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/82
Depends on https://github.com/wso2/identity-apps/pull/1518

Changing the default pages to point to the newly moved pages in the authentication portal

Part of https://github.com/wso2/product-is/issues/10998