### PR TITLE
[5.2.0] Support account locking for TOTP

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>rampart-trust</artifactId>
             <version>${rampart.wso2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>
@@ -95,11 +99,6 @@
             <artifactId>powermock-module-junit4</artifactId>
             <version>1.6.5</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-            <version>${encoder.wso2.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -96,6 +96,11 @@
             <version>1.6.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>${encoder.wso2.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -37,6 +37,9 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
 	public static final String ENCODING_CLAIM_URL = "http://wso2.org/claims/identity/encoding";
 	public static final String FIRST_NAME_CLAIM_URL = "http://wso2.org/claims/givenname";
+	public static final String FAILED_TOTP_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedTotpAttempts";
+	public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+	public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
 	public static final String BASE32 = "Base32";
 	public static final String BASE64 = "Base64";
 	public static final String APPLICATION_AUTHENTICATION_XML = "application-authentication.xml";
@@ -67,4 +70,8 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
+	public static final String AUTHENTICATED_USER = "authenticatedUser";
+	public static final String LOCAL_AUTHENTICATOR = "LOCAL";
+	public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+	public static final String ADMIN_INITIATED = "AdminInitiated";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPAuthenticatorServiceComponent.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticator;
+import org.wso2.carbon.identity.mgt.account.lock.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -36,6 +37,9 @@ import java.util.Hashtable;
  * unbind="unsetConfigurationContextService"
  * @scr.reference name="user.realmservice.default" interface="org.wso2.carbon.user.core.service.RealmService"
  * cardinality="1..1" policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ * @scr.reference name="org.wso2.carbon.identity.mgt.account.lock.AccountLockService"
+ * interface="org.wso2.carbon.identity.mgt.account.lock.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService" unbind="unsetAccountLockService"
  */
 public class TOTPAuthenticatorServiceComponent {
 
@@ -105,5 +109,25 @@ public class TOTPAuthenticatorServiceComponent {
 	 */
 	protected void unsetRealmService(RealmService realmService) {
 		TOTPDataHolder.getInstance().setRealmService(null);
+	}
+
+	/**
+	 * This method is used to unset the Account Lock Service.
+	 *
+	 * @param accountLockService The Account Lock Service which needs to set.
+	 */
+	protected void setAccountLockService(AccountLockService accountLockService) {
+
+		TOTPDataHolder.getInstance().setAccountLockService(accountLockService);
+	}
+
+	/**
+	 * This method is used to unset the Account Lock Service.
+	 *
+	 * @param accountLockService The Account Lock Service which needs to set.
+	 */
+	protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+		TOTPDataHolder.getInstance().setAccountLockService(null);
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/internal/TOTPDataHolder.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.identity.application.authenticator.totp.internal;
 
+import org.wso2.carbon.identity.mgt.account.lock.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -30,6 +31,7 @@ public class TOTPDataHolder {
 	private static TOTPDataHolder instance = new TOTPDataHolder();
 	private RealmService realmService;
 	private ConfigurationContextService configurationContextService;
+	private AccountLockService accountLockService;
 
 	/**
 	 * Returns the DataHolder instance.
@@ -75,5 +77,25 @@ public class TOTPDataHolder {
 	public void setConfigurationContextService(
 			ConfigurationContextService configurationContextService) {
 		this.configurationContextService = configurationContextService;
+	}
+
+	/**
+	 * Get the AccountLock service.
+	 *
+	 * @return AccountLock service.
+	 */
+	public AccountLockService getAccountLockService() {
+
+		return accountLockService;
+	}
+
+	/**
+	 * Set the AccountLock service.
+	 *
+	 * @param accountLockService The AccountLock service.
+	 */
+	public void setAccountLockService(AccountLockService accountLockService) {
+
+		this.accountLockService = accountLockService;
 	}
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -36,12 +36,14 @@ import org.wso2.carbon.extension.identity.helper.util.IdentityHelperUtil;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.mgt.AccountLockServiceException;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -542,5 +544,58 @@ public class TOTPUtil {
 					.valueOf(context.getProperty(TOTPAuthenticatorConstants.ENABLE_TOTP_REQUEST_PAGE_URL));
 		}
 		return enableTOTPPage;
+	}
+
+	/**
+	 * Check whether account locking is enabled for TOTP.
+	 *
+	 * @return True if account locking is enabled for TOTP.
+	 */
+	public static boolean isAccountLockingEnabledForTotp() {
+
+		return Boolean.parseBoolean(
+				getTOTPParameters().get(TOTPAuthenticatorConstants.ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS));
+	}
+
+	/**
+	 * Check whether the user account is locked.
+	 *
+	 * @param userName        The username of the user.
+	 * @param tenantDomain    The tenant domain.
+	 * @param userStoreDomain The userstore domain.
+	 * @return True if the account is locked.
+	 * @throws AuthenticationFailedException Exception on authentication failure.
+	 */
+	public static boolean isAccountLocked(String userName, String tenantDomain, String userStoreDomain)
+			throws AuthenticationFailedException {
+
+		try {
+			return TOTPDataHolder.getInstance().getAccountLockService()
+					.isAccountLocked(userName, tenantDomain, userStoreDomain);
+		} catch (AccountLockServiceException e) {
+			throw new AuthenticationFailedException(
+					String.format("Error while validating account lock status of user: %s.", userName), e);
+		}
+	}
+
+	/**
+	 * Check whether the user being authenticated via a local authenticator or not.
+	 *
+	 * @param context Authentication context.
+	 * @return Whether the user being authenticated via a local authenticator.
+	 */
+	public static boolean isLocalUser(AuthenticationContext context) {
+
+		Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+		if (stepConfigMap == null) {
+			return false;
+		}
+		for (StepConfig stepConfig : stepConfigMap.values()) {
+			if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep() && StringUtils
+					.equals(TOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR, stepConfig.getAuthenticatedIdP())) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.version>5.2.2</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
                 <artifactId>org.wso2.carbon.identity.mgt</artifactId>
                 <version>${carbon.identity.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${encoder.wso2.version}</version>
+            </dependency>
             <!--Test Dependencies-->
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
## Purpose
Backport fix of https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/73
Related PR: https://github.com/wso2-support/carbon-identity-framework/pull/1440

Writing unit tests is in progress. Unit tests will be added before merging the PR.