### PR TITLE
Add config to hide the user store name from username in TOTP QR code url

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -73,7 +73,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TOTP_AUTHENTICATION_ENDPOINT_URL = "TOTPAuthenticationEndpointURL";
 	public static final String TOTP_ISSUER = "Issuer";
 	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
-	public static final String TOTP_HIDE_USERSTORE_FROM_USERNAME = "hide_user_store_from_display_name";
+	public static final String TOTP_HIDE_USERSTORE_FROM_USERNAME = "HideUserStoreFromDisplayInQRUrl";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 	public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -73,7 +73,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TOTP_AUTHENTICATION_ENDPOINT_URL = "TOTPAuthenticationEndpointURL";
 	public static final String TOTP_ISSUER = "Issuer";
 	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
-	public static final String TOTP_HIDE_USERSTORE_FROM_USERNAME = "HideUserStoreFromTOTPDisplayName";
+	public static final String TOTP_HIDE_USERSTORE_FROM_USERNAME = "hide_user_store_from_display_name";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 	public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -73,6 +73,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String TOTP_AUTHENTICATION_ENDPOINT_URL = "TOTPAuthenticationEndpointURL";
 	public static final String TOTP_ISSUER = "Issuer";
 	public static final String TOTP_COMMON_ISSUER = "UseCommonIssuer";
+	public static final String TOTP_HIDE_USERSTORE_FROM_USERNAME = "HideUserStoreFromTOTPDisplayName";
 	public static final String TOTP_AUTHENTICATION_ERROR_PAGE_URL = "TOTPAuthenticationEndpointErrorPage";
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 	public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -92,8 +92,9 @@ public class TOTPKeyGenerator {
                 }
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
+                String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantDomain, context, tenantAwareUsername);
                 String qrCodeURL =
-                        "otpauth://totp/" + issuer + ":" + tenantAwareUsername + "?secret=" + secretKey + "&issuer=" +
+                        "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                                 issuer + "&period=" + timeStep;
                 encodedQRCodeURL = Base64.encodeBase64String(qrCodeURL.getBytes());
                 claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL, encodedQRCodeURL);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -92,7 +92,7 @@ public class TOTPKeyGenerator {
                 }
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
-                String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantDomain, context, tenantAwareUsername);
+                String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
                 String qrCodeURL =
                         "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                                 issuer + "&period=" + timeStep;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -130,23 +130,13 @@ public class TOTPUtil {
     /**
      * Returns back the display name which will be used for the TOTP QR code URL.
      *
-     * @param tenantDomain  Tenant domain
-     * @param context       Context
      * @param tenantAwareUsername   Tenant aware username
      * @return  Username
      */
-    public static String getTOTPDisplayUsername(String tenantDomain, AuthenticationContext context,
-                                                String tenantAwareUsername) {
+    public static String getTOTPDisplayUsername(String tenantAwareUsername) {
 
-        String hideUserStoreConfig;
-        if (context != null && context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME) != null) {
-            hideUserStoreConfig = (String) context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME);
-        } else if (SUPER_TENANT_DOMAIN.equals(tenantDomain)) {
-            hideUserStoreConfig = getTOTPParameters().get(TOTP_HIDE_USERSTORE_FROM_USERNAME);
-        } else {
-            hideUserStoreConfig = getConfigFromRegistry(tenantDomain, TOTP_HIDE_USERSTORE_FROM_USERNAME);
-        }
-        if (StringUtils.isNotEmpty(hideUserStoreConfig) && Boolean.parseBoolean(hideUserStoreConfig)) {
+        String hideUserStoreConfig = getTOTPParameters().get(TOTP_HIDE_USERSTORE_FROM_USERNAME);
+        if (Boolean.parseBoolean(hideUserStoreConfig)) {
             return UserCoreUtil.removeDomainFromName(tenantAwareUsername);
         }
         return tenantAwareUsername;
@@ -179,24 +169,6 @@ public class TOTPUtil {
             PrivilegedCarbonContext.endTenantFlow();
         }
         return issuer;
-    }
-
-    private static String getConfigFromRegistry(String tenantDomain, String configKey) {
-
-        int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
-        try {
-            NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);
-            return getAttributeFromRegistry(authConfigList, configKey);
-        } catch (Exception e) {
-            //Default to tenant domain name on registry exception.
-            if (log.isDebugEnabled()) {
-                log.debug("Error while reading the value for " + configKey + " from the tenant registry." +
-                        " Falling back to the server config.");
-            }
-            return getTOTPParameters().get(configKey);
-        } finally {
-            PrivilegedCarbonContext.endTenantFlow();
-        }
     }
 
     private static String getAttributeFromRegistry(NodeList authConfigList, String attributeTag) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -138,7 +138,7 @@ public class TOTPUtil {
     public static String getTOTPDisplayUsername(String tenantDomain, AuthenticationContext context,
                                                 String tenantAwareUsername) {
 
-        String hideUserStoreConfig = null;
+        String hideUserStoreConfig;
         if (context != null && context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME) != null) {
             hideUserStoreConfig = (String) context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME);
         } else if (SUPER_TENANT_DOMAIN.equals(tenantDomain)) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -55,6 +55,7 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.xml.sax.SAXException;
 
@@ -73,6 +74,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ENABLE_TOTP_REQUEST_PAGE;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ERROR_PAGE;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.TOTP_HIDE_USERSTORE_FROM_USERNAME;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE;
 
 /**
@@ -125,6 +128,31 @@ public class TOTPUtil {
     }
 
     /**
+     * Returns back the display name which will be used for the TOTP QR code URL.
+     *
+     * @param tenantDomain  Tenant domain
+     * @param context       Context
+     * @param tenantAwareUsername   Tenant aware username
+     * @return  Username
+     */
+    public static String getTOTPDisplayUsername(String tenantDomain, AuthenticationContext context,
+                                                String tenantAwareUsername) {
+
+        String hideUserStoreConfig = null;
+        if (context != null && context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME) != null) {
+            hideUserStoreConfig = (String) context.getProperty(TOTP_HIDE_USERSTORE_FROM_USERNAME);
+        } else if (SUPER_TENANT_DOMAIN.equals(tenantDomain)) {
+            hideUserStoreConfig = getTOTPParameters().get(TOTP_HIDE_USERSTORE_FROM_USERNAME);
+        } else {
+            hideUserStoreConfig = getConfigFromRegistry(tenantDomain, TOTP_HIDE_USERSTORE_FROM_USERNAME);
+        }
+        if (StringUtils.isNotEmpty(hideUserStoreConfig) && Boolean.parseBoolean(hideUserStoreConfig)) {
+            return UserCoreUtil.removeDomainFromName(tenantAwareUsername);
+        }
+        return tenantAwareUsername;
+    }
+
+    /**
      * Get xml file data from registry and get the value for Issuer.
      *
      * @param tenantDomain
@@ -151,6 +179,24 @@ public class TOTPUtil {
             PrivilegedCarbonContext.endTenantFlow();
         }
         return issuer;
+    }
+
+    private static String getConfigFromRegistry(String tenantDomain, String configKey) {
+
+        int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
+        try {
+            NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);
+            return getAttributeFromRegistry(authConfigList, configKey);
+        } catch (Exception e) {
+            //Default to tenant domain name on registry exception.
+            if (log.isDebugEnabled()) {
+                log.debug("Error while reading the value for " + configKey + " from the tenant registry." +
+                        " Falling back to the server config.");
+            }
+            return getTOTPParameters().get(configKey);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 
     private static String getAttributeFromRegistry(NodeList authConfigList, String attributeTag) {


### PR DESCRIPTION
## Purpose
>  Add config to hide the user store name from username in TOTP QR code url
Adding the following config to deployment.toml will remove the user store name from the TOTP TOTP QR code URL and will be displayed in the TOTP authenticator
```
[authentication.authenticator.totp.parameters]
hide_user_store_from_display_name=true
```

Config added with https://github.com/wso2/carbon-identity-framework/pull/3384