### PR TITLE
Enable TOTP for federated users

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -621,7 +621,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                                               AuthenticationContext context) throws TOTPException {
 
         if (context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID) == null) {
-            throw new TOTPException("Error wile getting the federated user id for the user: " );
+            throw new TOTPException("Error wile getting the federated user id for the user: ");
         }
         String userId = context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID).toString();
         String secretKey = TOTPUtil.getSecretKey(context, userId);
@@ -852,7 +852,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             if (userId == null) {
                 userId = UUID.randomUUID().toString();
                 UserSessionStore.getInstance().storeUserData(userId, username, tenantId,
-                            userStoreDomain, idpId);
+                        userStoreDomain, idpId);
             }
         } catch (UserSessionException e) {
             throw new TOTPException("Error while storing session data for user: " + username + " of " +

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -616,7 +616,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
      * @param tenantDomain Tenant domain.
      * @param context      Authentication context
      * @return true if token is valid otherwise false
-     * @throws TOTPException UserRealm for user or tenant domain is null
+     * @throws TOTPException If an error occurred while validating token.
      */
     private boolean isValidTokenFederatedUser(int token, String tenantDomain,
                                               AuthenticationContext context) throws TOTPException {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -78,6 +78,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ENABLE_TOTP_REQUEST_PAGE_URL = "TOTPAuthenticationEndpointEnableTOTPPage";
 	public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";
 	public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
+	public static final String ATTRIBUTE_EMAIL_SENT_TO = "send-to";
 	public static final String EVENT_NAME = "TOTP";
 	public static final String AUTHENTICATED_USER = "authenticatedUser";
 	public static final String LOCAL_AUTHENTICATOR = "LOCAL";
@@ -88,6 +89,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
 	public static final String ADMIN_INITIATED = "AdminInitiated";
 	public static final String FEDERATED_USER_ID = "FederatedUserId";
+	public static final String FEDERATED_EMAIL_ATTRIBUTE_KEY = "email";
 
 	public static final String ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL = "AllowSendingVerificationCodeByEmail";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -87,6 +87,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
 	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
 	public static final String ADMIN_INITIATED = "AdminInitiated";
+	public static final String FEDERATED_USER_ID = "FederatedUserId";
 
 	public static final String ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL = "AllowSendingVerificationCodeByEmail";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -117,7 +117,7 @@ public class TOTPKeyGenerator {
      * @throws TOTPException If an error occurred while generating claims.
      */
     private static Map<String, String> getGeneratedClaims(String username, String tenantDomain, String storedSecretKey,
-                                                         boolean refresh, long timeStep, AuthenticationContext context)
+                                                          boolean refresh, long timeStep, AuthenticationContext context)
             throws TOTPException {
 
         String secretKey;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -104,6 +104,18 @@ public class TOTPKeyGenerator {
         return claims;
     }
 
+    /**
+     * Generate TOTP related claims.
+     *
+     * @param username Username.
+     * @param tenantDomain Tenant domain.
+     * @param storedSecretKey Stored secret key.
+     * @param refresh Boolean type of refreshing the secret token
+     * @param timeStep Time stamp.
+     * @param context Authentication context.
+     * @return TOTP related claims.
+     * @throws TOTPException If an error occurred while generating claims.
+     */
     public static Map<String, String> getGeneratedClaims(String username, String tenantDomain, String storedSecretKey,
                                                          boolean refresh, long timeStep, AuthenticationContext context)
             throws TOTPException {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -107,12 +107,12 @@ public class TOTPKeyGenerator {
     /**
      * Generate TOTP related claims.
      *
-     * @param username Username.
-     * @param tenantDomain Tenant domain.
+     * @param username        Username.
+     * @param tenantDomain    Tenant domain.
      * @param storedSecretKey Stored secret key.
-     * @param refresh Boolean type of refreshing the secret token
-     * @param timeStep Time stamp.
-     * @param context Authentication context.
+     * @param refresh         Boolean type of refreshing the secret token
+     * @param timeStep        Time stamp.
+     * @param context         Authentication context.
      * @return TOTP related claims.
      * @throws TOTPException If an error occurred while generating claims.
      */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -55,10 +55,7 @@ public class TOTPKeyGenerator {
     public static Map<String, String> generateClaims(String username, boolean refresh, AuthenticationContext context)
             throws TOTPException {
 
-        String storedSecretKey, secretKey;
-        String decryptedSecretKey = null;
-        String generatedSecretKey = null;
-        String encodedQRCodeURL;
+        String storedSecretKey;
         String tenantAwareUsername = null;
         Map<String, String> claims = new HashMap<>();
         long timeStep;
@@ -66,43 +63,79 @@ public class TOTPKeyGenerator {
             UserRealm userRealm = TOTPUtil.getUserRealm(username);
             String tenantDomain = MultitenantUtils.getTenantDomain(username);
             tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-            if (context == null) {
-                timeStep = TOTPUtil.getTimeStepSize(tenantDomain);
-            } else {
-                timeStep = TOTPUtil.getTimeStepSize(context);
-            }
+            timeStep = getTimeStamp(context, username);
             if (userRealm != null) {
                 Map<String, String> userClaimValues = userRealm.getUserStoreManager().
                         getUserClaimValues(tenantAwareUsername, new String[]{
                                 TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
                 storedSecretKey =
                         userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
-                if (StringUtils.isEmpty(storedSecretKey) || refresh) {
-                    TOTPAuthenticatorKey key = generateKey(tenantDomain, context);
-                    generatedSecretKey = key.getKey();
-                    claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
-                            TOTPUtil.encrypt(generatedSecretKey));
-                } else {
-                    decryptedSecretKey = TOTPUtil.decrypt(storedSecretKey);
-                }
-                if (StringUtils.isNotEmpty(generatedSecretKey)) {
-                    secretKey = generatedSecretKey;
-                } else {
-                    secretKey = decryptedSecretKey;
-                }
-
-                String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
-                String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-                String qrCodeURL =
-                        "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
-                                issuer + "&period=" + timeStep;
-                encodedQRCodeURL = Base64.encodeBase64String(qrCodeURL.getBytes());
-                claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL, encodedQRCodeURL);
+                claims = getGeneratedClaims(username, tenantDomain, storedSecretKey, refresh, timeStep, context);
             }
         } catch (UserStoreException e) {
             throw new TOTPException(
                     "TOTPKeyGenerator failed while trying to get the user store manager from user realm of the user : " +
                             tenantAwareUsername, e);
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException(
+                    "TOTPKeyGenerator cannot find the property value for encoding method", e);
+        }
+        return claims;
+    }
+
+    /**
+     * Generate TOTP secret key for federated user, encoding method and QR Code url for user.
+     *
+     * @param username        Username of the user.
+     * @param storedSecretKey Stored secret key.
+     * @param refresh         Boolean type of refreshing the secret token.
+     * @param context         Authentication context.
+     * @return Generated TOTP related claims of federated user.
+     * @throws TOTPException when user realm is null or while decrypting the key
+     */
+    public static Map<String, String> generateClaimsForFedUser(String username, String tenantDomain,
+                                                               String storedSecretKey, boolean refresh,
+                                                               AuthenticationContext context)
+            throws TOTPException {
+
+        long timeStep = getTimeStamp(context, username);
+        Map<String, String> claims =
+                getGeneratedClaims(username, tenantDomain, storedSecretKey, refresh, timeStep, context);
+        return claims;
+    }
+
+    public static Map<String, String> getGeneratedClaims(String username, String tenantDomain, String storedSecretKey,
+                                                         boolean refresh, long timeStep, AuthenticationContext context)
+            throws TOTPException {
+
+        String secretKey;
+        String encodedQRCodeURL;
+        String decryptedSecretKey = null;
+        String generatedSecretKey = null;
+        Map<String, String> claims = new HashMap<>();
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        try {
+            if (StringUtils.isEmpty(storedSecretKey) || refresh) {
+                TOTPAuthenticatorKey key = generateKey(tenantDomain, context);
+                generatedSecretKey = key.getKey();
+                claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
+                        TOTPUtil.encrypt(generatedSecretKey));
+            } else {
+                decryptedSecretKey = TOTPUtil.decrypt(storedSecretKey);
+            }
+            if (StringUtils.isNotEmpty(generatedSecretKey)) {
+                secretKey = generatedSecretKey;
+            } else {
+                secretKey = decryptedSecretKey;
+            }
+
+            String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
+            String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
+            String qrCodeURL =
+                    "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
+                            issuer + "&period=" + timeStep;
+            encodedQRCodeURL = Base64.encodeBase64String(qrCodeURL.getBytes());
+            claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL, encodedQRCodeURL);
         } catch (CryptoException e) {
             throw new TOTPException("TOTPKeyGenerator failed while decrypt the storedSecretKey ", e);
         } catch (AuthenticationFailedException e) {
@@ -110,6 +143,23 @@ public class TOTPKeyGenerator {
                     "TOTPKeyGenerator cannot find the property value for encoding method", e);
         }
         return claims;
+    }
+
+    public static long getTimeStamp(AuthenticationContext context, String username) throws TOTPException {
+
+        long timeStep;
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        try {
+            if (context == null) {
+                timeStep = TOTPUtil.getTimeStepSize(tenantDomain);
+            } else {
+                timeStep = TOTPUtil.getTimeStepSize(context);
+            }
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException(
+                    "TOTPKeyGenerator cannot get stored time step size", e);
+        }
+        return timeStep;
     }
 
     /**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -121,7 +121,7 @@ public class TOTPTokenGenerator {
 						storedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
 					}
 
-					String secretKey = TOTPUtil.decrypt(storedSecretKey);
+                    String secretKey = TOTPUtil.decrypt(storedSecretKey);
 					String firstName = userRealm
 							.getUserStoreManager().getUserClaimValue
 									(tenantAwareUsername,
@@ -131,57 +131,57 @@ public class TOTPTokenGenerator {
 							                        (tenantAwareUsername,
 							                         TOTPAuthenticatorConstants.EMAIL_CLAIM_URL,
 							                         null);
-					AuthenticatedUser authenticatedUser = (AuthenticatedUser) context
-							.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
-					token = sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, firstName, secretKey,
-							email, tenantDomain, context);
-				} else {
-					throw new TOTPException(
-							"Cannot find the user realm for the given tenant domain : " +
-									CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-				}
-			} catch (UserStoreException e) {
-				throw new TOTPException(
-						"TOTPTokenGenerator failed while trying to access userRealm of the user : " +
-								tenantAwareUsername, e);
-			} catch (CryptoException e) {
-				throw new TOTPException("Error while decrypting the key", e);
-			} catch (AuthenticationFailedException e) {
-				throw new TOTPException(
-						"TOTPTokenVerifier cannot find the property value for encodingMethod");
-			}
-		}
-		return Long.toString(token);
-	}
+                    AuthenticatedUser authenticatedUser = (AuthenticatedUser) context
+                            .getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
+                    token = sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, firstName, secretKey,
+                            email, tenantDomain, context);
+                } else {
+                    throw new TOTPException(
+                            "Cannot find the user realm for the given tenant domain : " +
+                                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+                }
+            } catch (UserStoreException e) {
+                throw new TOTPException(
+                        "TOTPTokenGenerator failed while trying to access userRealm of the user : " +
+                                tenantAwareUsername, e);
+            } catch (CryptoException e) {
+                throw new TOTPException("Error while decrypting the key", e);
+            } catch (AuthenticationFailedException e) {
+                throw new TOTPException(
+                        "TOTPTokenVerifier cannot find the property value for encodingMethod");
+            }
+        }
+        return Long.toString(token);
+    }
 
-	/**
-	 * Generate TOTP token for a federated user.
-	 *
-	 * @param username Username of the user.
-	 * @param context  Authentication context.
-	 * @throws TOTPException When could not find user realm for the given tenant domain, invalid.
-	 *                       secret key, decrypting invalid key and could not find the configured hashing algorithm.
-	 */
-	public static void generateTOTPTokenFederatedUser(String username, AuthenticatedUser authenticatedUser,
-													  AuthenticationContext context)
-			throws TOTPException {
+    /**
+     * Generate TOTP token for a federated user.
+     *
+     * @param username Username of the user.
+     * @param context  Authentication context.
+     * @throws TOTPException When could not find user realm for the given tenant domain, invalid.
+     *                       secret key, decrypting invalid key and could not find the configured hashing algorithm.
+     */
+    public static void generateTOTPTokenFederatedUser(String username, AuthenticatedUser authenticatedUser,
+                                                      AuthenticationContext context)
+            throws TOTPException {
 
-		if (context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID) == null) {
-			throw new TOTPException("Error wile getting the federated user id for the user: ");
-		}
-		String userId = context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID).toString();
+        if (context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID) == null) {
+            throw new TOTPException("Error wile getting the federated user id for the user: ");
+        }
+        String userId = context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID).toString();
 
-		String tenantAwareUsername = authenticatedUser.getUserName();
-		if (username != null) {
-			String secretKey = TOTPUtil.getSecretKey(context, userId);
-			Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();
-			String email = getEmailForFederatedUser(userAttributes);
-			String tenantDomain = authenticatedUser.getTenantDomain();
+        String tenantAwareUsername = authenticatedUser.getUserName();
+        if (username != null) {
+            String secretKey = TOTPUtil.getSecretKey(context, userId);
+            Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();
+            String email = getEmailForFederatedUser(userAttributes);
+            String tenantDomain = authenticatedUser.getTenantDomain();
 
-			sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, username, secretKey,
-					email, tenantDomain, context);
-		}
-	}
+            sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, username, secretKey,
+                    email, tenantDomain, context);
+        }
+    }
 
 	private static long sendEmailWithToken(String username, AuthenticatedUser authenticatedUser,
 										   String tenantAwareUsername, String firstName, String secretKey,
@@ -208,7 +208,7 @@ public class TOTPTokenGenerator {
 				triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(), email,
 						authenticatedUser.getUserStoreDomain(), TOTPAuthenticatorConstants.EVENT_NAME,
 						Long.toString(token));
-			} else{
+			} else {
 				sendNotification(tenantAwareUsername, firstName, tenantDomain, Long.toString(token), email);
 			}
 			if (log.isDebugEnabled()) {
@@ -227,24 +227,24 @@ public class TOTPTokenGenerator {
 		return token;
 	}
 
-	/**
-	 * Extract the email value from federated user attributes.
-	 *
-	 * @param userAttributes Map with federated user attributes.
-	 * @return Email attribute.
-	 */
-	private static String getEmailForFederatedUser(Map<ClaimMapping, String> userAttributes) {
+    /**
+     * Extract the email value from federated user attributes.
+     *
+     * @param userAttributes Map with federated user attributes.
+     * @return Email attribute.
+     */
+    private static String getEmailForFederatedUser(Map<ClaimMapping, String> userAttributes) {
 
-		String email = null;
-		for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
-			String key = String.valueOf(entry.getKey().getLocalClaim().getClaimUri());
-			String value = entry.getValue();
-			if ((TOTPAuthenticatorConstants.FEDERATED_EMAIL_ATTRIBUTE_KEY).equals(key)) {
-				email = String.valueOf(value);
-				break;
-			}
-		}
-		return email;
+        String email = null;
+        for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+            String key = String.valueOf(entry.getKey().getLocalClaim().getClaimUri());
+            String value = entry.getValue();
+            if ((TOTPAuthenticatorConstants.FEDERATED_EMAIL_ATTRIBUTE_KEY).equals(key)) {
+                email = String.valueOf(value);
+                break;
+            }
+        }
+        return email;
 	}
 
 	/**
@@ -344,8 +344,8 @@ public class TOTPTokenGenerator {
 	 * @param email               Email address of the user
 	 * @throws TOTPException MAILTO transport sender is not defined
 	 */
-	private static void sendNotification(String tenantAwareUsername, String firstName, String tenantDomain,
-										 String token, String email) throws TOTPException {
+    private static void sendNotification(String tenantAwareUsername, String firstName, String tenantDomain,
+                                         String token, String email) throws TOTPException {
 		ConfigurationContext configurationContext =
 				TOTPDataHolder.getInstance().getConfigurationContextService()
 				              .getServerConfigContext();
@@ -402,15 +402,15 @@ public class TOTPTokenGenerator {
 	 *
 	 * @param userName : Identity user name
 	 * @param tenantDomain : Tenant domain of the user.
-	 * @param sendToAddress  The email address to send the otp.
+     * @param sendToAddress  The email address to send the otp.
 	 * @param userStoreDomainName : User store domain name of the user.
 	 * @param notificationEvent : The name of the event.
 	 * @param otpCode : The OTP code returned for the authentication request.
 	 * @throws AuthenticationFailedException : In occasions of failing sending the email to the user.
 	 */
-	private static void triggerEvent(String userName, String tenantDomain, String sendToAddress,
-									 String userStoreDomainName, String notificationEvent, String otpCode)
-			throws AuthenticationFailedException {
+    private static void triggerEvent(String userName, String tenantDomain, String sendToAddress,
+                                     String userStoreDomainName, String notificationEvent, String otpCode)
+            throws AuthenticationFailedException {
 
 		String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
 		HashMap<String, Object> properties = new HashMap<>();

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -72,65 +72,65 @@ import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthen
  */
 public class TOTPTokenGenerator {
 
-	private static final String FIRST_NAME = "firstname";
-	private static final String TOTP_TOKEN = "totp-token";
-	private static final Log log = LogFactory.getLog(TOTPTokenGenerator.class);
+    private static final String FIRST_NAME = "firstname";
+    private static final String TOTP_TOKEN = "totp-token";
+    private static final Log log = LogFactory.getLog(TOTPTokenGenerator.class);
 
-	private static final int TOKEN_HASH_DIVISOR = 1000000;
-	// Max number of attempts to calculate a token with minimum chars.
-	private static final int MAX_TOKEN_CALCULATE_ATTEMPTS = 5;
+    private static final int TOKEN_HASH_DIVISOR = 1000000;
+    // Max number of attempts to calculate a token with minimum chars.
+    private static final int MAX_TOKEN_CALCULATE_ATTEMPTS = 5;
 
-	/**
-	 * Get Time steps from unix epoch time.
-	 *
-	 * @return Time index
-	 */
-	private static long getTimeIndex(AuthenticationContext context) throws TOTPException {
-		return System.currentTimeMillis() / 1000 / TOTPUtil.getTimeStepSize(context);
-	}
+    /**
+     * Get Time steps from unix epoch time.
+     *
+     * @return Time index
+     */
+    private static long getTimeIndex(AuthenticationContext context) throws TOTPException {
+        return System.currentTimeMillis() / 1000 / TOTPUtil.getTimeStepSize(context);
+    }
 
-	/**
-	 * Generate TOTP token for a locally stored user.
-	 *
-	 * @param username Username of the user
-	 * @param context  Authentication context
-	 * @return TOTP token as a String
-	 * @throws TOTPException When could not find user realm for the given tenant domain, invalid
-	 * secret key, decrypting invalid key and could not find the configured hashing algorithm
-	 */
-	public static String generateTOTPTokenLocal(String username, AuthenticationContext context)
-			throws TOTPException {
+    /**
+     * Generate TOTP token for a locally stored user.
+     *
+     * @param username Username of the user
+     * @param context  Authentication context
+     * @return TOTP token as a String
+     * @throws TOTPException When could not find user realm for the given tenant domain, invalid
+     *                       secret key, decrypting invalid key and could not find the configured hashing algorithm
+     */
+    public static String generateTOTPTokenLocal(String username, AuthenticationContext context)
+            throws TOTPException {
 
-		long token = 0;
-		String tenantAwareUsername = null;
-		if (username != null) {
-			try {
-				String tenantDomain = MultitenantUtils.getTenantDomain(username);
-				UserRealm userRealm = TOTPUtil.getUserRealm(username);
-				tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-				if (userRealm != null) {
-					String storedSecretKey;
-					if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
-						storedSecretKey =
-								context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
-					} else {
-						Map<String, String> userClaimValues =
-								userRealm.getUserStoreManager().getUserClaimValues
-										(tenantAwareUsername, new String[]{
-												TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
-						storedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
-					}
+        long token = 0;
+        String tenantAwareUsername = null;
+        if (username != null) {
+            try {
+                String tenantDomain = MultitenantUtils.getTenantDomain(username);
+                UserRealm userRealm = TOTPUtil.getUserRealm(username);
+                tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+                if (userRealm != null) {
+                    String storedSecretKey;
+                    if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
+                        storedSecretKey =
+                                context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
+                    } else {
+                        Map<String, String> userClaimValues =
+                                userRealm.getUserStoreManager().getUserClaimValues
+                                        (tenantAwareUsername, new String[]{
+                                                TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
+                        storedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+                    }
 
                     String secretKey = TOTPUtil.decrypt(storedSecretKey);
-					String firstName = userRealm
-							.getUserStoreManager().getUserClaimValue
-									(tenantAwareUsername,
-									 TOTPAuthenticatorConstants.FIRST_NAME_CLAIM_URL, null);
-					String email = userRealm.getUserStoreManager()
-					                        .getUserClaimValue
-							                        (tenantAwareUsername,
-							                         TOTPAuthenticatorConstants.EMAIL_CLAIM_URL,
-							                         null);
+                    String firstName = userRealm
+                            .getUserStoreManager().getUserClaimValue
+                                    (tenantAwareUsername,
+                                            TOTPAuthenticatorConstants.FIRST_NAME_CLAIM_URL, null);
+                    String email = userRealm.getUserStoreManager()
+                            .getUserClaimValue
+                                    (tenantAwareUsername,
+                                            TOTPAuthenticatorConstants.EMAIL_CLAIM_URL,
+                                            null);
                     AuthenticatedUser authenticatedUser = (AuthenticatedUser) context
                             .getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
                     token = sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, firstName, secretKey,
@@ -183,49 +183,49 @@ public class TOTPTokenGenerator {
         }
     }
 
-	private static long sendEmailWithToken(String username, AuthenticatedUser authenticatedUser,
-										   String tenantAwareUsername, String firstName, String secretKey,
-										   String email, String tenantDomain, AuthenticationContext context)
-			throws TOTPException {
+    private static long sendEmailWithToken(String username, AuthenticatedUser authenticatedUser,
+                                           String tenantAwareUsername, String firstName, String secretKey,
+                                           String email, String tenantDomain, AuthenticationContext context)
+            throws TOTPException {
 
-		long token;
-		byte[] secretKeyByteArray;
-		try {
-			String encoding = TOTPUtil.getEncodingMethod(tenantDomain, context);
-			if (TOTPAuthenticatorConstants.BASE32.equals(encoding)) {
-				Base32 codec32 = new Base32();
-				secretKeyByteArray = codec32.decode(secretKey);
-			} else {
-				Base64 codec64 = new Base64();
-				secretKeyByteArray = codec64.decode(secretKey);
-			}
-			token = generateToken(username, tenantDomain, secretKeyByteArray, context);
-			// Check whether the authenticator is configured to use the event handler implementation.
-			if (TOTPUtil.isEventHandlerBasedEmailSenderEnabled()) {
-				if (log.isDebugEnabled()) {
-					log.debug("TOTP authenticator configured to use the event handler implementation.");
-				}
-				triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(), email,
-						authenticatedUser.getUserStoreDomain(), TOTPAuthenticatorConstants.EVENT_NAME,
-						Long.toString(token));
-			} else {
-				sendNotification(tenantAwareUsername, firstName, tenantDomain, Long.toString(token), email);
-			}
-			if (log.isDebugEnabled()) {
-				log.debug(
-						"Token is sent to via email to the user : " + tenantAwareUsername);
-			}
-		} catch (NoSuchAlgorithmException e) {
-			throw new TOTPException(
-					"TOTPTokenGenerator can't find the configured hashing algorithm", e);
-		} catch (InvalidKeyException e) {
-			throw new TOTPException("Secret key is not valid", e);
-		} catch (AuthenticationFailedException e) {
-			throw new TOTPException(
-					"TOTPTokenVerifier cannot find the property value for encodingMethod");
-		}
-		return token;
-	}
+        long token;
+        byte[] secretKeyByteArray;
+        try {
+            String encoding = TOTPUtil.getEncodingMethod(tenantDomain, context);
+            if (TOTPAuthenticatorConstants.BASE32.equals(encoding)) {
+                Base32 codec32 = new Base32();
+                secretKeyByteArray = codec32.decode(secretKey);
+            } else {
+                Base64 codec64 = new Base64();
+                secretKeyByteArray = codec64.decode(secretKey);
+            }
+            token = generateToken(username, tenantDomain, secretKeyByteArray, context);
+            // Check whether the authenticator is configured to use the event handler implementation.
+            if (TOTPUtil.isEventHandlerBasedEmailSenderEnabled()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("TOTP authenticator configured to use the event handler implementation.");
+                }
+                triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(), email,
+                        authenticatedUser.getUserStoreDomain(), TOTPAuthenticatorConstants.EVENT_NAME,
+                        Long.toString(token));
+            } else {
+                sendNotification(tenantAwareUsername, firstName, tenantDomain, Long.toString(token), email);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Token is sent to via email to the user : " + tenantAwareUsername);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new TOTPException(
+                    "TOTPTokenGenerator can't find the configured hashing algorithm", e);
+        } catch (InvalidKeyException e) {
+            throw new TOTPException("Secret key is not valid", e);
+        } catch (AuthenticationFailedException e) {
+            throw new TOTPException(
+                    "TOTPTokenVerifier cannot find the property value for encodingMethod");
+        }
+        return token;
+    }
 
     /**
      * Extract the email value from federated user attributes.
@@ -245,187 +245,187 @@ public class TOTPTokenGenerator {
             }
         }
         return email;
-	}
+    }
 
-	/**
-	 * Generate 6 digit TOTP token for a given secret key and time index.
-	 *
-	 * @param username Username of the user.
-	 * @param tenantDomain Tenant domain of the user.
-	 * @param secret  Secret key in binary format.
-	 * @param context Authentication context.
-	 * @return Six digit TOTP token value as a long.
-	 * @throws NoSuchAlgorithmException If the specific algorithm was not found.
-	 * @throws InvalidKeyException      If an invalid signKey provided.
-	 * @throws TOTPException            If an error occurred while getting the time index.
-	 */
-	private static long generateToken(String username, String tenantDomain, byte[] secret,
-									  AuthenticationContext context)
-			throws NoSuchAlgorithmException, InvalidKeyException, TOTPException {
+    /**
+     * Generate 6 digit TOTP token for a given secret key and time index.
+     *
+     * @param username     Username of the user.
+     * @param tenantDomain Tenant domain of the user.
+     * @param secret       Secret key in binary format.
+     * @param context      Authentication context.
+     * @return Six digit TOTP token value as a long.
+     * @throws NoSuchAlgorithmException If the specific algorithm was not found.
+     * @throws InvalidKeyException      If an invalid signKey provided.
+     * @throws TOTPException            If an error occurred while getting the time index.
+     */
+    private static long generateToken(String username, String tenantDomain, byte[] secret,
+                                      AuthenticationContext context)
+            throws NoSuchAlgorithmException, InvalidKeyException, TOTPException {
 
-		long token = getCode(secret, getTimeIndex(context));
-		// We need to check whether the token at least have the minimum number of digits.
-		if (isTokenHasMinimumChars(token)) {
-			return token;
-		}
+        long token = getCode(secret, getTimeIndex(context));
+        // We need to check whether the token at least have the minimum number of digits.
+        if (isTokenHasMinimumChars(token)) {
+            return token;
+        }
 		/*
 		Calculate a new token with minimum chars. If we cannot generate an acceptable char within 5 attempts
 		(MAX_TOKEN_CALCULATE_ATTEMPTS), we need to send the last generated code. This is highly unlikely scenario.
 		 */
-		for (int count = 0; count < MAX_TOKEN_CALCULATE_ATTEMPTS; count++) {
-			token = getCode(secret, getTimeIndex(context));
-			if (isTokenHasMinimumChars(token)) {
-				return token;
-			}
-		}
-		if (log.isDebugEnabled()) {
-			log.debug(String.format("Unable to generate a token with max character length for user: %s in " +
-					"tenant: %s.Therefore, sending the generated token in attempt: %s", username, tenantDomain,
-					MAX_TOKEN_CALCULATE_ATTEMPTS));
-		}
-		return token;
-	}
+        for (int count = 0; count < MAX_TOKEN_CALCULATE_ATTEMPTS; count++) {
+            token = getCode(secret, getTimeIndex(context));
+            if (isTokenHasMinimumChars(token)) {
+                return token;
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Unable to generate a token with max character length for user: %s in " +
+                            "tenant: %s.Therefore, sending the generated token in attempt: %s", username, tenantDomain,
+                    MAX_TOKEN_CALCULATE_ATTEMPTS));
+        }
+        return token;
+    }
 
-	/**
-	 * Check whether the token has the minimum number of chars in it.
-	 *
-	 * @param token Generated token.
-	 * @return True if the token has the minimum number of chars.
-	 */
-	private static boolean isTokenHasMinimumChars(long token) {
+    /**
+     * Check whether the token has the minimum number of chars in it.
+     *
+     * @param token Generated token.
+     * @return True if the token has the minimum number of chars.
+     */
+    private static boolean isTokenHasMinimumChars(long token) {
 
 		/*
 		If we can get a number which is larger than 0, when the token is multiplied by 10 and divided by
 		TOKEN_HASH_DIVISOR, that means the token has the minimum number of chars.
 		 */
-		return token * 10 / TOKEN_HASH_DIVISOR > 0;
-	}
+        return token * 10 / TOKEN_HASH_DIVISOR > 0;
+    }
 
-	/**
-	 * Create the TOTP token for a given secret key and time index.
-	 *
-	 * @param secret    Secret key in binary format
-	 * @param timeIndex Number of Time elapse from the unix epoch time
-	 * @return TOTP token value as a long
-	 * @throws NoSuchAlgorithmException Could not find the specific algorithm
-	 * @throws InvalidKeyException      invalid signKey
-	 */
-	private static long getCode(byte[] secret, long timeIndex)
-			throws NoSuchAlgorithmException, InvalidKeyException {
-		// Building the secret key specification for the HmacSHA1 algorithm.
-		SecretKeySpec signKey =
-				new SecretKeySpec(secret, TOTPAuthenticatorConstants.HMAC_ALGORITHM);
-		ByteBuffer buffer = ByteBuffer.allocate(8);
-		buffer.putLong(timeIndex);
-		byte[] timeBytes = buffer.array();
-		// Getting an HmacSHA1 algorithm implementation from the Java Cryptography Extension (JCE).
-		Mac mac = Mac.getInstance(TOTPAuthenticatorConstants.HMAC_ALGORITHM);
-		// Initializing the MAC algorithm.
-		mac.init(signKey);
-		// Processing the instant of time and getting the encrypted data.
-		byte[] hash = mac.doFinal(timeBytes);
-		// Building the validation code performing dynamic truncation.
-		int offset = hash[19] & 0xf;
-		long truncatedHash = hash[offset] & 0x7f;
-		for (int i = 1; i < 4; i++) {
-			truncatedHash <<= 8;
-			truncatedHash |= hash[offset + i] & 0xff;
-		}
-		truncatedHash %= TOKEN_HASH_DIVISOR;
-		return truncatedHash;
-	}
+    /**
+     * Create the TOTP token for a given secret key and time index.
+     *
+     * @param secret    Secret key in binary format
+     * @param timeIndex Number of Time elapse from the unix epoch time
+     * @return TOTP token value as a long
+     * @throws NoSuchAlgorithmException Could not find the specific algorithm
+     * @throws InvalidKeyException      invalid signKey
+     */
+    private static long getCode(byte[] secret, long timeIndex)
+            throws NoSuchAlgorithmException, InvalidKeyException {
+        // Building the secret key specification for the HmacSHA1 algorithm.
+        SecretKeySpec signKey =
+                new SecretKeySpec(secret, TOTPAuthenticatorConstants.HMAC_ALGORITHM);
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(timeIndex);
+        byte[] timeBytes = buffer.array();
+        // Getting an HmacSHA1 algorithm implementation from the Java Cryptography Extension (JCE).
+        Mac mac = Mac.getInstance(TOTPAuthenticatorConstants.HMAC_ALGORITHM);
+        // Initializing the MAC algorithm.
+        mac.init(signKey);
+        // Processing the instant of time and getting the encrypted data.
+        byte[] hash = mac.doFinal(timeBytes);
+        // Building the validation code performing dynamic truncation.
+        int offset = hash[19] & 0xf;
+        long truncatedHash = hash[offset] & 0x7f;
+        for (int i = 1; i < 4; i++) {
+            truncatedHash <<= 8;
+            truncatedHash |= hash[offset + i] & 0xff;
+        }
+        truncatedHash %= TOKEN_HASH_DIVISOR;
+        return truncatedHash;
+    }
 
-	/**
-	 * Send the TOTP token via MAILTO transport.
-	 *
-	 * @param tenantAwareUsername Tenant aware username of user
-	 * @param firstName           First name of user
-	 * @param token               Token which needs to be sent to user
-	 * @param email               Email address of the user
-	 * @throws TOTPException MAILTO transport sender is not defined
-	 */
+    /**
+     * Send the TOTP token via MAILTO transport.
+     *
+     * @param tenantAwareUsername Tenant aware username of user
+     * @param firstName           First name of user
+     * @param token               Token which needs to be sent to user
+     * @param email               Email address of the user
+     * @throws TOTPException MAILTO transport sender is not defined
+     */
     private static void sendNotification(String tenantAwareUsername, String firstName, String tenantDomain,
                                          String token, String email) throws TOTPException {
-		ConfigurationContext configurationContext =
-				TOTPDataHolder.getInstance().getConfigurationContextService()
-				              .getServerConfigContext();
-		if (configurationContext.getAxisConfiguration().getTransportsOut()
-		                        .containsKey(TOTPAuthenticatorConstants.TRANSPORT_MAILTO)) {
-			NotificationSender notificationSender = new NotificationSender();
-			NotificationDataDTO notificationData = new NotificationDataDTO();
-			Notification emailNotification;
-			NotificationData emailNotificationData = new NotificationData();
-			ConfigBuilder configBuilder = ConfigBuilder.getInstance();
-			NotificationSendingModule module = new DefaultEmailSendingModule();
-			int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-			String emailTemplate = null;
-			Config config;
-			try {
-				config = configBuilder
-						.loadConfiguration(ConfigType.EMAIL, StorageType.REGISTRY, tenantId);
-			} catch (IdentityMgtConfigException e) {
-				throw new TOTPException("Error occurred while loading email templates for user : " +
-				                        tenantAwareUsername, e);
-			}
-			emailNotificationData.setTagData(FIRST_NAME, firstName);
-			emailNotificationData.setTagData(TOTP_TOKEN, token);
-			emailNotificationData.setSendTo(email);
-			if (config.getProperties()
-			          .containsKey(TOTPAuthenticatorConstants.EMAIL_TEMPLATE_NAME)) {
-				emailTemplate = config.getProperty(TOTPAuthenticatorConstants.EMAIL_TEMPLATE_NAME);
-				try {
-					emailNotification = NotificationBuilder
-							.createNotification("EMAIL", emailTemplate, emailNotificationData);
-				} catch (IdentityMgtServiceException e) {
-					log.error("Error occurred while creating notification from email template : " +
-					          emailTemplate, e);
-					throw new TOTPException(
-							"Error occurred while creating notification from email template : " +
-							emailTemplate, e);
-				}
-				notificationData.setNotificationAddress(email);
-				module.setNotificationData(notificationData);
-				module.setNotification(emailNotification);
-				notificationSender.sendNotification(module);
-				notificationData.setNotificationSent(true);
-			} else {
-				throw new TOTPException("Unable to find the email template: " + emailTemplate);
-			}
-		} else {
-			throw new TOTPException(
-					"MAILTO transport sender is not defined in axis2 configuration file");
-		}
-	}
+        ConfigurationContext configurationContext =
+                TOTPDataHolder.getInstance().getConfigurationContextService()
+                        .getServerConfigContext();
+        if (configurationContext.getAxisConfiguration().getTransportsOut()
+                .containsKey(TOTPAuthenticatorConstants.TRANSPORT_MAILTO)) {
+            NotificationSender notificationSender = new NotificationSender();
+            NotificationDataDTO notificationData = new NotificationDataDTO();
+            Notification emailNotification;
+            NotificationData emailNotificationData = new NotificationData();
+            ConfigBuilder configBuilder = ConfigBuilder.getInstance();
+            NotificationSendingModule module = new DefaultEmailSendingModule();
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            String emailTemplate = null;
+            Config config;
+            try {
+                config = configBuilder
+                        .loadConfiguration(ConfigType.EMAIL, StorageType.REGISTRY, tenantId);
+            } catch (IdentityMgtConfigException e) {
+                throw new TOTPException("Error occurred while loading email templates for user : " +
+                        tenantAwareUsername, e);
+            }
+            emailNotificationData.setTagData(FIRST_NAME, firstName);
+            emailNotificationData.setTagData(TOTP_TOKEN, token);
+            emailNotificationData.setSendTo(email);
+            if (config.getProperties()
+                    .containsKey(TOTPAuthenticatorConstants.EMAIL_TEMPLATE_NAME)) {
+                emailTemplate = config.getProperty(TOTPAuthenticatorConstants.EMAIL_TEMPLATE_NAME);
+                try {
+                    emailNotification = NotificationBuilder
+                            .createNotification("EMAIL", emailTemplate, emailNotificationData);
+                } catch (IdentityMgtServiceException e) {
+                    log.error("Error occurred while creating notification from email template : " +
+                            emailTemplate, e);
+                    throw new TOTPException(
+                            "Error occurred while creating notification from email template : " +
+                                    emailTemplate, e);
+                }
+                notificationData.setNotificationAddress(email);
+                module.setNotificationData(notificationData);
+                module.setNotification(emailNotification);
+                notificationSender.sendNotification(module);
+                notificationData.setNotificationSent(true);
+            } else {
+                throw new TOTPException("Unable to find the email template: " + emailTemplate);
+            }
+        } else {
+            throw new TOTPException(
+                    "MAILTO transport sender is not defined in axis2 configuration file");
+        }
+    }
 
-	/**
-	 * Method to Trigger the TOTP otp event.
-	 *
-	 * @param userName : Identity user name
-	 * @param tenantDomain : Tenant domain of the user.
-     * @param sendToAddress  The email address to send the otp.
-	 * @param userStoreDomainName : User store domain name of the user.
-	 * @param notificationEvent : The name of the event.
-	 * @param otpCode : The OTP code returned for the authentication request.
-	 * @throws AuthenticationFailedException : In occasions of failing sending the email to the user.
-	 */
+    /**
+     * Method to Trigger the TOTP otp event.
+     *
+     * @param userName            : Identity user name
+     * @param tenantDomain        : Tenant domain of the user.
+     * @param sendToAddress       The email address to send the otp.
+     * @param userStoreDomainName : User store domain name of the user.
+     * @param notificationEvent   : The name of the event.
+     * @param otpCode             : The OTP code returned for the authentication request.
+     * @throws AuthenticationFailedException : In occasions of failing sending the email to the user.
+     */
     private static void triggerEvent(String userName, String tenantDomain, String sendToAddress,
                                      String userStoreDomainName, String notificationEvent, String otpCode)
             throws AuthenticationFailedException {
 
-		String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
-		HashMap<String, Object> properties = new HashMap<>();
-		properties.put(IdentityEventConstants.EventProperty.USER_NAME, userName);
-		properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomainName);
-		properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
-		properties.put(TOKEN, otpCode);
-		properties.put(TOTPAuthenticatorConstants.TEMPLATE_TYPE, notificationEvent);
-		properties.put(TOTPAuthenticatorConstants.ATTRIBUTE_EMAIL_SENT_TO, sendToAddress);
-		Event identityMgtEvent = new Event(eventName, properties);
-		try {
-			TOTPDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
-		} catch (IdentityEventException e) {
-			String errorMsg = "Error occurred while calling triggerNotification. " + e.getMessage();
-			throw new AuthenticationFailedException(errorMsg, e.getCause());
-		}
-	}
+        String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, userName);
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomainName);
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        properties.put(TOKEN, otpCode);
+        properties.put(TOTPAuthenticatorConstants.TEMPLATE_TYPE, notificationEvent);
+        properties.put(TOTPAuthenticatorConstants.ATTRIBUTE_EMAIL_SENT_TO, sendToAddress);
+        Event identityMgtEvent = new Event(eventName, properties);
+        try {
+            TOTPDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            String errorMsg = "Error occurred while calling triggerNotification. " + e.getMessage();
+            throw new AuthenticationFailedException(errorMsg, e.getCause());
+        }
+    }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -111,7 +111,8 @@ public class TOTPTokenGenerator {
 				if (userRealm != null) {
 					String storedSecretKey;
 					if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
-						storedSecretKey = context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
+						storedSecretKey =
+								context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
 					} else {
 						Map<String, String> userClaimValues =
 								userRealm.getUserStoreManager().getUserClaimValues
@@ -171,25 +172,14 @@ public class TOTPTokenGenerator {
 		String userId = context.getProperty(TOTPAuthenticatorConstants.FEDERATED_USER_ID).toString();
 
 		String tenantAwareUsername = authenticatedUser.getUserName();
-		String storedSecretKey;
 		if (username != null) {
-			try {
-				if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
-					storedSecretKey = context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
-				} else {
-					storedSecretKey = DAOFactory.getInstance().getTOTPSecretKeyDAO().
-							getTOTPSecretKeyOfFederatedUser(userId);
-				}
-				String secretKey = TOTPUtil.decrypt(storedSecretKey);
-				Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();
-				String email = getEmailForFederatedUser(userAttributes);
-				String tenantDomain = authenticatedUser.getTenantDomain();
+			String secretKey = TOTPUtil.getSecretKey(context, userId);
+			Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();
+			String email = getEmailForFederatedUser(userAttributes);
+			String tenantDomain = authenticatedUser.getTenantDomain();
 
-				sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, username, secretKey,
-						email, tenantDomain, context);
-			} catch (CryptoException e) {
-				throw new TOTPException("Error while decrypting the key", e);
-			}
+			sendEmailWithToken(username, authenticatedUser, tenantAwareUsername, username, secretKey,
+					email, tenantDomain, context);
 		}
 	}
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -109,15 +109,17 @@ public class TOTPTokenGenerator {
 				UserRealm userRealm = TOTPUtil.getUserRealm(username);
 				tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
 				if (userRealm != null) {
-					Map<String, String> userClaimValues =
-							userRealm.getUserStoreManager().getUserClaimValues
-									(tenantAwareUsername, new String[] {
-											TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL }, null);
-					String storedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
-					if (StringUtils.isEmpty(storedSecretKey) &&
-							(context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null)) {
+					String storedSecretKey;
+					if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
 						storedSecretKey = context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
+					} else {
+						Map<String, String> userClaimValues =
+								userRealm.getUserStoreManager().getUserClaimValues
+										(tenantAwareUsername, new String[]{
+												TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
+						storedSecretKey = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
 					}
+
 					String secretKey = TOTPUtil.decrypt(storedSecretKey);
 					String firstName = userRealm
 							.getUserStoreManager().getUserClaimValue
@@ -172,11 +174,11 @@ public class TOTPTokenGenerator {
 		String storedSecretKey;
 		if (username != null) {
 			try {
-				storedSecretKey = DAOFactory.getInstance().getTOTPSecretKeyDAO().
-						getTOTPSecretKeyOfFederatedUser(userId);
-				if (StringUtils.isEmpty(storedSecretKey) &&
-						(context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null)) {
+				if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
 					storedSecretKey = context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
+				} else {
+					storedSecretKey = DAOFactory.getInstance().getTOTPSecretKeyDAO().
+							getTOTPSecretKeyOfFederatedUser(userId);
 				}
 				String secretKey = TOTPUtil.decrypt(storedSecretKey);
 				Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/DAOFactory.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/DAOFactory.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.totp.dao;
+
+import org.wso2.carbon.identity.application.authenticator.totp.dao.Impl.TOTPSecretKeyDAOImpl;
+
+/**
+ * TOTP Secret key DAO factory.
+ */
+public class DAOFactory {
+
+    private static final DAOFactory factory = new DAOFactory();
+    private final TOTPSecretKeyDAO totpSecretKeyDAO;
+
+    private DAOFactory() {
+
+        this.totpSecretKeyDAO = new TOTPSecretKeyDAOImpl();
+    }
+
+    public static DAOFactory getInstance() {
+
+        return factory;
+    }
+
+    /**
+     * Get the TOTP Secret Key DAO.
+     *
+     * @return TOTP Secret Key DAO.
+     */
+    public TOTPSecretKeyDAO getTOTPSecretKeyDAO() {
+
+        return totpSecretKeyDAO;
+    }
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/Impl/TOTPSecretKeyDAOImpl.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/Impl/TOTPSecretKeyDAOImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.totp.dao.Impl;
+
+import org.wso2.carbon.identity.application.authenticator.totp.dao.TOTPSecretKeyDAO;
+import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
+import org.wso2.carbon.identity.application.authenticator.totp.util.SQLQueries;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Default implementation of {@link TOTPSecretKeyDAO}. This handles DB operations related to configuring TOTP
+ * for the federated users.
+ */
+public class TOTPSecretKeyDAOImpl implements TOTPSecretKeyDAO {
+
+    @Override
+    public void setTOTPSecretKeyOfFederatedUser(String userId, String secretKey) throws TOTPException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection()) {
+            try (PreparedStatement preparedStatement = connection
+                    .prepareStatement(SQLQueries.SQL_INSERT_TOTP_SECRET_KEY)) {
+                preparedStatement.setString(1, userId);
+                preparedStatement.setString(2, secretKey);
+                preparedStatement.executeUpdate();
+                IdentityDatabaseUtil.commitTransaction(connection);
+            } catch (SQLException e1) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
+                throw new TOTPException("Error when store secret key for the federated user: " + userId, e1);
+            }
+        } catch (SQLException e) {
+            throw new TOTPException("Error while storing secret key against federated user id: " + userId, e);
+        }
+    }
+
+    @Override
+    public String getTOTPSecretKeyOfFederatedUser(String userId) throws TOTPException {
+
+        String secretKey = null;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+            try (PreparedStatement preparedStatement = connection
+                    .prepareStatement(SQLQueries.SQL_SELECT_SECRET_KEY_OF_USER_ID)) {
+                preparedStatement.setString(1, userId);
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    if (resultSet.next()) {
+                        secretKey = resultSet.getString(1);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new TOTPException("Error while getting the secret key against federated user id: " + userId, e);
+        }
+        return secretKey;
+    }
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/TOTPSecretKeyDAO.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/TOTPSecretKeyDAO.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.totp.dao;
+
+import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
+
+/**
+ * TOTPSecretKeyDAO interface to handle TOTP secret key for federated user related DAO operations.
+ */
+public interface TOTPSecretKeyDAO {
+
+    /**
+     * Store secret key for federated user.
+     *
+     * @param userId    Federated user id.
+     * @param secretKey TOTP Secret key of the federated user.
+     * @throws TOTPException if an error occurs when storing the secret key for a federated user.
+     */
+    void setTOTPSecretKeyOfFederatedUser(String userId, String secretKey) throws TOTPException;
+
+    /**
+     * Get the secret key y the federated user id.
+     *
+     * @param userId Federated user id.
+     * @return TOTP secret key of the federated user.
+     * @throws TOTPException if an error occurs while retrieving the secret key of a federated user
+     */
+    String getTOTPSecretKeyOfFederatedUser(String userId) throws TOTPException;
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/TOTPSecretKeyDAO.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/dao/TOTPSecretKeyDAO.java
@@ -34,7 +34,7 @@ public interface TOTPSecretKeyDAO {
     void setTOTPSecretKeyOfFederatedUser(String userId, String secretKey) throws TOTPException;
 
     /**
-     * Get the secret key y the federated user id.
+     * Get the secret key for the federated user id.
      *
      * @param userId Federated user id.
      * @return TOTP secret key of the federated user.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/SQLQueries.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/SQLQueries.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authenticator.totp.util;
+
+/**
+ * This class holds the SQL queries used by TOTPAuthenticator.
+ */
+public class SQLQueries {
+
+    public static final String SQL_INSERT_TOTP_SECRET_KEY =
+            "INSERT INTO IDN_FEDERATED_USER_TOTP_SECRET_KEY(USER_ID, SECRET_KEY) VALUES (?,?)";
+
+    public static final String SQL_SELECT_SECRET_KEY_OF_USER_ID =
+            "SELECT SECRET_KEY FROM IDN_FEDERATED_USER_TOTP_SECRET_KEY WHERE USER_ID = ?";
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/SQLQueries.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/SQLQueries.java
@@ -23,8 +23,8 @@ package org.wso2.carbon.identity.application.authenticator.totp.util;
 public class SQLQueries {
 
     public static final String SQL_INSERT_TOTP_SECRET_KEY =
-            "INSERT INTO IDN_FEDERATED_USER_TOTP_SECRET_KEY(USER_ID, SECRET_KEY) VALUES (?,?)";
+            "INSERT INTO IDN_FED_USER_TOTP_SECRET_KEY(USER_ID, SECRET_KEY) VALUES (?,?)";
 
     public static final String SQL_SELECT_SECRET_KEY_OF_USER_ID =
-            "SELECT SECRET_KEY FROM IDN_FEDERATED_USER_TOTP_SECRET_KEY WHERE USER_ID = ?";
+            "SELECT SECRET_KEY FROM IDN_FED_USER_TOTP_SECRET_KEY WHERE USER_ID = ?";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -821,11 +821,13 @@ public class TOTPUtil {
 
         AuthenticatedUser authenticatedUser = null;
         Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
-        for (StepConfig stepConfig : stepConfigMap.values()) {
-            AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
-            if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
-                authenticatedUser = new AuthenticatedUser(stepConfig.getAuthenticatedUser());
-                break;
+        if (stepConfigMap != null) {
+            for (StepConfig stepConfig : stepConfigMap.values()) {
+                AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
+                if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
+                    authenticatedUser = new AuthenticatedUser(stepConfig.getAuthenticatedUser());
+                    break;
+                }
             }
         }
         return authenticatedUser;

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -443,6 +443,7 @@ public class TOTPAuthenticatorTest {
     public void testInitiateAuthenticationRequestWithNullUser() throws AuthenticationFailedException {
 
         context.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
     }
 
@@ -477,7 +478,7 @@ public class TOTPAuthenticatorTest {
         when(TOTPUtil.getErrorPageFromXMLFile(any(AuthenticationContext.class), anyString())).
                 thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
         when(TOTPUtil.getTOTPLoginPage(any(AuthenticationContext.class))).thenCallRealMethod();
-
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, authenticationContext);
     }
 
@@ -508,6 +509,7 @@ public class TOTPAuthenticatorTest {
         when(mockedMap.get(anyObject())).thenReturn(stepConfig);
         when(stepConfig.getAuthenticatedAutenticator()).thenReturn(authenticatorConfig);
         when(authenticatorConfig.getApplicationAuthenticator()).thenReturn(applicationAuthenticator);
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, mockedContext);
         Assert.assertEquals(mockedContext.getProperty(TOTPAuthenticatorConstants.AUTHENTICATION),
                 TOTPAuthenticatorConstants.FEDERETOR);
@@ -552,7 +554,7 @@ public class TOTPAuthenticatorTest {
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
         mockServiceURLBuilder();
-
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
         verify(httpServletResponse).sendRedirect(captor.capture());
 
@@ -588,6 +590,7 @@ public class TOTPAuthenticatorTest {
         when(TOTPUtil.getErrorPageFromXMLFile(any(AuthenticationContext.class), anyString())).
                 thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
         when(TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(context)).thenReturn(true);
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
     }
 

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -507,17 +507,7 @@ public class TOTPAuthenticatorTest {
         authenticatedUser.setUserName("testuser@gmail.com");
         authenticatedUser.setFederatedUser(true);
         mockedContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
-        when(mockedContext.getSequenceConfig()).thenReturn(sequenceConfig);
-
-        StepConfig stepConfig = new StepConfig();
-        stepConfig.setAuthenticatedUser(authenticatedUser);
-        stepConfig.setSubjectAttributeStep(true);
-        stepConfig.setAuthenticatedIdP("Facebook");
-
-        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
-        stepConfigMap.put(1, stepConfig);
-
-        when(sequenceConfig.getStepMap()).thenReturn(stepConfigMap);
+        when(TOTPUtil.getAuthenticatedUser(mockedContext)).thenReturn(authenticatedUser);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         when(UserSessionStore.getInstance()).thenReturn(userSessionStore);
         when(userSessionStore.getIdPId(anyString(), anyInt())).thenReturn(2);
@@ -666,15 +656,7 @@ public class TOTPAuthenticatorTest {
         mockedContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
         when(mockedContext.getSequenceConfig()).thenReturn(sequenceConfig);
 
-        StepConfig stepConfig = new StepConfig();
-        stepConfig.setAuthenticatedUser(authenticatedUser);
-        stepConfig.setSubjectAttributeStep(true);
-        stepConfig.setAuthenticatedIdP("Facebook");
-
-        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
-        stepConfigMap.put(1, stepConfig);
-
-        when(sequenceConfig.getStepMap()).thenReturn(stepConfigMap);
+        when(TOTPUtil.getAuthenticatedUser(mockedContext)).thenReturn(authenticatedUser);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         when(UserSessionStore.getInstance()).thenReturn(userSessionStore);
         when(userSessionStore.getIdPId(anyString(), anyInt())).thenReturn(2);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -44,12 +44,17 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
+import org.wso2.carbon.identity.application.authenticator.totp.dao.DAOFactory;
+import org.wso2.carbon.identity.application.authenticator.totp.dao.TOTPSecretKeyDAO;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -70,17 +75,16 @@ import javax.servlet.http.HttpServletResponse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.*;
 
 @PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, ConfigurationFacade.class, TOTPTokenGenerator.class,
         FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, CarbonContext.class,
-        FederatedAuthenticatorUtil.class, IdentityUtil.class, ServiceURLBuilder.class})
+        FederatedAuthenticatorUtil.class, IdentityUtil.class, ServiceURLBuilder.class, IdentityTenantUtil.class,
+        UserSessionStore.class, DAOFactory.class, TOTPSecretKeyDAO.class})
 @PowerMockIgnore({"javax.crypto.*"})
 public class TOTPAuthenticatorTest {
 
@@ -140,6 +144,15 @@ public class TOTPAuthenticatorTest {
 
     @Mock
     private ServiceURL serviceURL;
+
+    @Mock
+    UserSessionStore userSessionStore;
+
+    @Mock
+    DAOFactory daoFactory;
+
+    @Mock
+    TOTPSecretKeyDAO totpSecretKeyDAO;
 
     @BeforeMethod
     public void setUp() {
@@ -482,6 +495,50 @@ public class TOTPAuthenticatorTest {
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, authenticationContext);
     }
 
+    @Test(description = "Test case for initiateAuthenticationRequest() method with totp enabled federated user.")
+    public void testInitiateAuthenticationRequestWithFederatedUser()
+            throws AuthenticationFailedException, UserSessionException, TOTPException, URLBuilderException {
+
+        mockStatic(IdentityTenantUtil.class);
+        mockStatic(UserSessionStore.class);
+        mockStatic(DAOFactory.class);
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName("testuser@gmail.com");
+        authenticatedUser.setFederatedUser(true);
+        mockedContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
+        when(mockedContext.getSequenceConfig()).thenReturn(sequenceConfig);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        stepConfig.setAuthenticatedIdP("Facebook");
+
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        when(sequenceConfig.getStepMap()).thenReturn(stepConfigMap);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        when(UserSessionStore.getInstance()).thenReturn(userSessionStore);
+        when(userSessionStore.getIdPId(anyString(), anyInt())).thenReturn(2);
+        when(userSessionStore.getUserId(anyString(), anyInt(), anyString(), anyInt())).
+                thenReturn("22759552-a256-40ac-a0b8-7a993ff5965e");
+        when(DAOFactory.getInstance()).thenReturn(daoFactory);
+        when(daoFactory.getTOTPSecretKeyDAO()).thenReturn(totpSecretKeyDAO);
+        when(totpSecretKeyDAO.getTOTPSecretKeyOfFederatedUser(anyString())).
+                thenReturn("22759552-a256-40ac-a0b8-7a993ff5965e");
+        when(configurationFacade.getAuthenticationEndpointURL()).thenReturn("authenticationendpoint/login.do");
+        mockServiceURLBuilder();
+
+        when(TOTPUtil.getLoginPageFromXMLFile(any(AuthenticationContext.class), anyString())).
+                thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
+        when(TOTPUtil.getErrorPageFromXMLFile(any(AuthenticationContext.class), anyString())).
+                thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
+        when(TOTPUtil.getTOTPLoginPage(any(AuthenticationContext.class))).thenCallRealMethod();
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(false);
+        totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, mockedContext);
+    }
+
     @Test(description = "Test case for initiateAuthenticationRequest() method when admin does not enforces TOTP and " +
             "TOTP is not enabled for the user.")
     public void testInitiateAuthenticationRequestWithEnrollment() throws AuthenticationFailedException,
@@ -592,6 +649,51 @@ public class TOTPAuthenticatorTest {
         when(TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(context)).thenReturn(true);
         when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(true);
         totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
+    }
+
+    @Test(description = "Test case for initiateAuthenticationRequest() method when admin enforces TOTP and " +
+            "TOTP is not enabled for a federated user.")
+    public void testInitiateAuthenticationForFedUserWithEnableTOTP()
+            throws AuthenticationFailedException, UserSessionException, TOTPException {
+
+        mockStatic(IdentityTenantUtil.class);
+        mockStatic(UserSessionStore.class);
+        mockStatic(DAOFactory.class);
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName("testuser@gmail.com");
+        authenticatedUser.setFederatedUser(true);
+        mockedContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
+        when(mockedContext.getSequenceConfig()).thenReturn(sequenceConfig);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        stepConfig.setAuthenticatedIdP("Facebook");
+
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        when(sequenceConfig.getStepMap()).thenReturn(stepConfigMap);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        when(UserSessionStore.getInstance()).thenReturn(userSessionStore);
+        when(userSessionStore.getIdPId(anyString(), anyInt())).thenReturn(2);
+        when(userSessionStore.getUserId(anyString(), anyInt(), anyString(), anyInt())).
+                thenReturn("22759552-a256-40ac-a0b8-7a993ff5965e");
+
+        when(DAOFactory.getInstance()).thenReturn(daoFactory);
+        when(daoFactory.getTOTPSecretKeyDAO()).thenReturn(totpSecretKeyDAO);
+        when(totpSecretKeyDAO.getTOTPSecretKeyOfFederatedUser(anyString())).thenReturn(null);
+
+        when(httpServletRequest.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP)).thenReturn(null);
+        when(IdentityHelperUtil.checkSecondStepEnableByAdmin(mockedContext)).thenReturn(true);
+        when(TOTPUtil.getLoginPageFromXMLFile(any(AuthenticationContext.class), anyString())).
+                thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
+        when(TOTPUtil.getErrorPageFromXMLFile(any(AuthenticationContext.class), anyString())).
+                thenReturn(TOTPAuthenticatorConstants.TOTP_LOGIN_PAGE);
+        when(TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(mockedContext)).thenReturn(true);
+        when(TOTPUtil.isLocalUser(any(AuthenticationContext.class))).thenReturn(false);
+        totpAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, mockedContext);
     }
 
     @ObjectFactory


### PR DESCRIPTION
## Purpose
With this PR changes, federated users will be able to enable TOTP. 
Feature improvement issue: https://github.com/wso2-enterprise/asgardeo-product/issues/3029

## Approach
Introduce IDN_FED_USER_TOTP_SECRET_KEY table to store the secret key of the federated user aginst the federated userId generated for the user which is already in the IDN_AUTH_USER table.
Migration PR: https://github.com/wso2-extensions/identity-migration-resources/pull/193