### PR TITLE
Improvement to always return a 6-digit code.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -73,10 +73,6 @@ public class TOTPTokenGenerator {
 	private static final String TOTP_TOKEN = "totp-token";
 	private static final Log log = LogFactory.getLog(TOTPTokenGenerator.class);
 
-	private static final int TOKEN_HASH_DIVISOR = 1000000;
-	// Max number of attempts to calculate a token with minimum chars.
-	private static final int MAX_TOKEN_CALCULATE_ATTEMPTS = 5;
-
 	/**
 	 * Get Time steps from unix epoch time.
 	 *
@@ -129,7 +125,7 @@ public class TOTPTokenGenerator {
 						Base64 codec64 = new Base64();
 						secretKeyByteArray = codec64.decode(secretKey);
 					}
-					token = generateToken(username, tenantDomain, secretKeyByteArray, context);
+					token = getCode(secretKeyByteArray, getTimeIndex(context));
 					// Check whether the authenticator is configured to use the event handler implementation.
 					if (TOTPUtil.isEventHandlerBasedEmailSenderEnabled()) {
 						if (log.isDebugEnabled()) {
@@ -139,9 +135,9 @@ public class TOTPTokenGenerator {
 								.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
 						triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),
 								authenticatedUser.getUserStoreDomain(), TOTPAuthenticatorConstants.EVENT_NAME,
-								Long.toString(token));
+								String.format("%06d", token));
 					} else{
-						sendNotification(tenantAwareUsername, firstName, Long.toString(token), email);
+						sendNotification(tenantAwareUsername, firstName, String.format("%06d", token), email);
 					}
 					if (log.isDebugEnabled()) {
 						log.debug(
@@ -169,60 +165,6 @@ public class TOTPTokenGenerator {
 			}
 		}
 		return Long.toString(token);
-	}
-
-	/**
-	 * Generate 6 digit TOTP token for a given secret key and time index.
-	 *
-	 * @param username Username of the user.
-	 * @param tenantDomain Tenant domain of the user.
-	 * @param secret  Secret key in binary format.
-	 * @param context Authentication context.
-	 * @return Six digit TOTP token value as a long.
-	 * @throws NoSuchAlgorithmException If the specific algorithm was not found.
-	 * @throws InvalidKeyException      If an invalid signKey provided.
-	 * @throws TOTPException            If an error occurred while getting the time index.
-	 */
-	private static long generateToken(String username, String tenantDomain, byte[] secret,
-									  AuthenticationContext context)
-			throws NoSuchAlgorithmException, InvalidKeyException, TOTPException {
-
-		long token = getCode(secret, getTimeIndex(context));
-		// We need to check whether the token at least have the minimum number of digits.
-		if (isTokenHasMinimumChars(token)) {
-			return token;
-		}
-		/*
-		Calculate a new token with minimum chars. If we cannot generate an acceptable char within 5 attempts
-		(MAX_TOKEN_CALCULATE_ATTEMPTS), we need to send the last generated code. This is highly unlikely scenario.
-		 */
-		for (int count = 0; count < MAX_TOKEN_CALCULATE_ATTEMPTS; count++) {
-			token = getCode(secret, getTimeIndex(context));
-			if (isTokenHasMinimumChars(token)) {
-				return token;
-			}
-		}
-		if (log.isDebugEnabled()) {
-			log.debug(String.format("Unable to generate a token with max character length for user: %s in " +
-					"tenant: %s.Therefore, sending the generated token in attempt: %s", username, tenantDomain,
-					MAX_TOKEN_CALCULATE_ATTEMPTS));
-		}
-		return token;
-	}
-
-	/**
-	 * Check whether the token has the minimum number of chars in it.
-	 *
-	 * @param token Generated token.
-	 * @return True if the token has the minimum number of chars.
-	 */
-	private static boolean isTokenHasMinimumChars(long token) {
-
-		/*
-		If we can get a number which is larger than 0, when the token is multiplied by 10 and divided by
-		TOKEN_HASH_DIVISOR, that means the token has the minimum number of chars.
-		 */
-		return token * 10 / TOKEN_HASH_DIVISOR > 0;
 	}
 
 	/**
@@ -255,7 +197,7 @@ public class TOTPTokenGenerator {
 			truncatedHash <<= 8;
 			truncatedHash |= hash[offset + i] & 0xff;
 		}
-		truncatedHash %= TOKEN_HASH_DIVISOR;
+		truncatedHash %= 1000000;
 		return truncatedHash;
 	}
 


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/11457.

With the current implementation, we are attempting to generate a code that would not have a leading '0', i.e. a code with the pattern `[1-9][0-9]{5}`, thereby eliminating codes with leading zeros. This is not necessary since  `truncatedHash %= 1000000` can be for an instance `012345`, and it still would be a valid code.

Even if we use the above approach, with `MAX_TOKEN_CALCULATE_ATTEMPTS = 5`, this can still return a code (although highly unlikely) that would have `truncatedHash` with 5 digits.

With this fix, we are returning the `truncatedHash` as it is, and at the string conversion of the code, we would ensure that it has 6 digits by using `format(token, '06d’)`. 
 django-otp-twilio does this, for example.

