### PR TITLE
[5.11.0] Restrict sending totp using email as fallback option through a config

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -419,8 +419,9 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			String tenantDomain = context.getTenantDomain();
 			String sessionDataKey = context.getContextIdentifier();
 
-			String msg = "Sending verification code by email is disabled by admin. An attempt was made to send a " +
-					"verification code by email for user: %s for application: %s of %s tenant using sessionDataKey: %s";
+			String msg = "An attempt was made to send a verification code by email for user: %s " +
+					"for application: %s of %s tenant using sessionDataKey: %s. But sending verification code by " +
+					"email is disabled by admin.";
 			log.warn(String.format(msg, username, appName, tenantDomain, sessionDataKey));
 			return false;
 		}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -419,9 +419,9 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			String tenantDomain = context.getTenantDomain();
 			String sessionDataKey = context.getContextIdentifier();
 
-			String msg = "An attempt was made to send a verification code by email for user: %s " +
-					"for application: %s of %s tenant using sessionDataKey: %s. But sending verification code by " +
-					"email is disabled by admin.";
+			String msg = "An attempt was made to send a verification code by email for user: %s for application: %s " +
+					"of %s tenant using sessionDataKey: %s. But sending verification code by email is disabled by " +
+					"admin.";
 			log.warn(String.format(msg, username, appName, tenantDomain, sessionDataKey));
 			return false;
 		}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -419,7 +419,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			String tenantDomain = context.getTenantDomain();
 			String sessionDataKey = context.getContextIdentifier();
 
-			String msg = "Sending verification code by email is disabled by admin. At attempt was made to send a " +
+			String msg = "Sending verification code by email is disabled by admin. An attempt was made to send a " +
 					"verification code by email for user: %s for application: %s of %s tenant using sessionDataKey: %s";
 			log.warn(String.format(msg, username, appName, tenantDomain, sessionDataKey));
 			return false;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -100,7 +100,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		if (context.isLogoutRequest()) {
 			return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
 		} else if (request.getParameter(TOTPAuthenticatorConstants.SEND_TOKEN) != null) {
-			if (generateTOTPToken(context)) {
+			if (generateOTPAndSendByEmail(context)) {
 				return AuthenticatorFlowStatus.INCOMPLETE;
 			} else {
 				return AuthenticatorFlowStatus.FAIL_COMPLETED;
@@ -382,7 +382,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 	 */
 	@Override
 	public String getContextIdentifier(HttpServletRequest request) {
-		return request.getRequestedSessionId();
+		return request.getParameter("sessionDataKey");
 	}
 
 	/**
@@ -411,13 +411,24 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 	 * @param context AuthenticationContext
 	 * @return true, if token is generated successfully
 	 */
-	private boolean generateTOTPToken(AuthenticationContext context) {
-        String username;
-        if (context.getProperty("username") == null) {
+	private boolean generateOTPAndSendByEmail(AuthenticationContext context) {
+		String username = getUsernameFromContext(context);
+
+		if (!TOTPUtil.isSendVerificationCodeByEmailEnabled()) {
+			String appName = context.getServiceProviderName();
+			String tenantDomain = context.getTenantDomain();
+			String sessionDataKey = context.getContextIdentifier();
+
+			String msg = "Sending verification code by email is disabled by admin. At attempt was made to send a " +
+					"verification code by email for user: %s for application: %s of %s tenant using sessionDataKey: %s";
+			log.warn(String.format(msg, username, appName, tenantDomain, sessionDataKey));
+			return false;
+		}
+
+		if (username == null) {
             log.error("No username found in the authentication context.");
             return false;
         } else {
-            username = context.getProperty("username").toString();
             try {
                 TOTPTokenGenerator.generateTOTPTokenLocal(username, context);
                 if (log.isDebugEnabled()) {
@@ -429,6 +440,15 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             }
         }
         return true;
+	}
+
+	private String getUsernameFromContext(AuthenticationContext context) {
+
+		if (context.getProperty("username") == null) {
+			return null;
+		}
+
+		return context.getProperty("username").toString();
 	}
 
 	/**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -84,4 +84,5 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
 	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
 	public static final String ADMIN_INITIATED = "AdminInitiated";
+	public static final String ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL = "AllowSendingVerificationCodeByEmail";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -704,4 +704,19 @@ public class TOTPUtil {
 		}
 		return false;
 	}
+
+    /**
+     * Checks whether sending verification code via email option is enabled.
+     *
+     * Ideally for TOTP we shouldn't handle fallback options at the authenticator level. This is there for sake of
+     * backward compatibility. At the moment this option is a server level one.
+     *
+     * @return Whether sending verification code via email is enabled.
+     */
+    public static boolean isSendVerificationCodeByEmailEnabled() {
+
+        String sendVerificationCodeViaEmailConfig = getTOTPParameters()
+                .getOrDefault(TOTPAuthenticatorConstants.ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL, "false");
+        return Boolean.parseBoolean(sendVerificationCodeViaEmailConfig);
+    }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -156,9 +156,11 @@ public class TOTPAuthenticatorTest {
     @Test(description = "Test case for getContextIdentifier() method.")
     public void testGetContextIdentifier(){
         when(httpServletRequest.getRequestedSessionId()).thenReturn("234567890");
+        when(httpServletRequest.getParameter("sessionDataKey")).thenReturn("234567890");
         Assert.assertEquals(totpAuthenticator.getContextIdentifier(httpServletRequest), "234567890");
 
-        when(httpServletRequest.getRequestedSessionId()).thenReturn(null);
+        when(httpServletRequest.getRequestedSessionId()).thenReturn("234567890");
+        when(httpServletRequest.getParameter("sessionDataKey")).thenReturn(null);
         Assert.assertNull(totpAuthenticator.getContextIdentifier(httpServletRequest));
     }
 
@@ -219,9 +221,11 @@ public class TOTPAuthenticatorTest {
         String username = "admin";
         mockStatic(TOTPTokenGenerator.class);
         when(TOTPTokenGenerator.generateTOTPTokenLocal(username, new AuthenticationContext())).thenReturn("123456");
+        mockStatic(TOTPUtil.class);
+        when(TOTPUtil.isSendVerificationCodeByEmailEnabled()).thenReturn(true);
         AuthenticationContext authenticationContext = new AuthenticationContext();
         authenticationContext.setProperty("username", username);
-        Assert.assertTrue(Whitebox.invokeMethod(totpAuthenticator, "generateTOTPToken",
+        Assert.assertTrue(Whitebox.invokeMethod(totpAuthenticator, "generateOTPAndSendByEmail",
                 authenticationContext));
     }
 
@@ -238,12 +242,33 @@ public class TOTPAuthenticatorTest {
         AuthenticationContext authenticationContext = new AuthenticationContext();
         String username = "admin";
         authenticationContext.setProperty("username", username);
+        mockStatic(TOTPUtil.class);
+        when(TOTPUtil.isSendVerificationCodeByEmailEnabled()).thenReturn(true);
         doReturn(true).when(mockedTOTPAuthenticator).canHandle(httpServletRequest);
         when(httpServletRequest.getParameter(TOTPAuthenticatorConstants.SEND_TOKEN)).thenReturn("true");
         when(TOTPTokenGenerator.generateTOTPTokenLocal(username, authenticationContext)).thenReturn("123456");
         AuthenticatorFlowStatus status = totpAuthenticator.process(httpServletRequest, httpServletResponse,
                 authenticationContext);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+    }
+
+    @Test(description = "Test case for process() method with generate TOTP token with sending OTP by email disabled.")
+    public void testProcessWithSendOTPByEmailDisabled() throws AuthenticationFailedException, LogoutFailedException,
+            TOTPException {
+
+        AuthenticationContext authenticationContext = new AuthenticationContext();
+        String username = "admin";
+        authenticationContext.setProperty("username", username);
+
+        mockStatic(TOTPUtil.class);
+        when(TOTPUtil.isSendVerificationCodeByEmailEnabled()).thenReturn(false);
+
+        doReturn(true).when(mockedTOTPAuthenticator).canHandle(httpServletRequest);
+        when(httpServletRequest.getParameter(TOTPAuthenticatorConstants.SEND_TOKEN)).thenReturn("true");
+        when(TOTPTokenGenerator.generateTOTPTokenLocal(username, authenticationContext)).thenReturn("123456");
+        AuthenticatorFlowStatus status = totpAuthenticator.process(httpServletRequest, httpServletResponse,
+                authenticationContext);
+        Assert.assertEquals(status, AuthenticatorFlowStatus.FAIL_COMPLETED);
     }
 
     @Test(description = "Test case for process() method with send TOTP token failed.")


### PR DESCRIPTION
**Purpose**
Restrict sending totp using email as fallback option through a config.

Backport https://github.com/wso2/product-is/issues/11017 