### PR TITLE
Change the display name in TOTP for federated users.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -38,6 +38,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String VERIFY_SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/verifySecretkey";
 	public static final String ENCODING_CLAIM_URL = "http://wso2.org/claims/identity/encoding";
 	public static final String FIRST_NAME_CLAIM_URL = "http://wso2.org/claims/givenname";
+	public static final String LAST_NAME_CLAIM_URL = "http://wso2.org/claims/lastname";
 	public static final String TOTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedTotpAttempts";
 	public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
 			"http://wso2.org/claims/identity/failedLoginLockoutCount";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -88,6 +88,12 @@ public class TOTPKeyGenerator {
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
                 String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
+                if (context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                    String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context);
+                    if (displayUsernameForFederatedUser != null) {
+                        displayUsername = displayUsernameForFederatedUser;
+                    }
+                }
                 String qrCodeURL =
                         "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                                 issuer + "&period=" + timeStep;
@@ -132,6 +138,12 @@ public class TOTPKeyGenerator {
 
             String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
             String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
+            if (context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context);
+                if (displayUsernameForFederatedUser != null) {
+                    displayUsername = displayUsernameForFederatedUser;
+                }
+            }
             String qrCodeURL =
                     "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                             issuer + "&period=" + timeStep;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -88,7 +88,7 @@ public class TOTPKeyGenerator {
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
                 String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-                if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                if (isFederatedUser(context)) {
                     displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
                 }
                 String qrCodeURL =
@@ -135,7 +135,7 @@ public class TOTPKeyGenerator {
 
             String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
             String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-            if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+            if (isFederatedUser(context)) {
                 displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
             }
             String qrCodeURL =
@@ -311,5 +311,16 @@ public class TOTPKeyGenerator {
             username = displayUsernameForFederatedUser;
         }
         return username;
+    }
+
+    /**
+     * Check whether the user is federated or not.
+     *
+     * @param context Authentication context.
+     * @return Boolean whether user is federated or not.
+     */
+    private static boolean isFederatedUser(AuthenticationContext context) {
+
+        return context != null && context.getSubject() != null && context.getSubject().isFederatedUser();
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -88,9 +88,7 @@ public class TOTPKeyGenerator {
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
                 String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-                if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
-                    displayUsername = TOTPUtil.getTOTOIssuerDisplayNameForFederatedUser(context, displayUsername);
-                }
+                displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
                 String qrCodeURL =
                         "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                                 issuer + "&period=" + timeStep;
@@ -135,9 +133,7 @@ public class TOTPKeyGenerator {
 
             String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
             String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-            if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
-                displayUsername = TOTPUtil.getTOTOIssuerDisplayNameForFederatedUser(context, displayUsername);
-            }
+            displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
             String qrCodeURL =
                     "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                             issuer + "&period=" + timeStep;
@@ -293,5 +289,24 @@ public class TOTPKeyGenerator {
     public static TOTPAuthenticatorKey generateKey(String tenantDomain) throws AuthenticationFailedException {
 
         return generateKey(tenantDomain, null);
+    }
+
+    /**
+     * Get the display username for federated users.
+     *
+     * @param context  Authentication context.
+     * @param username Username of the authenticated user.
+     * @return Display username for federated users.
+     * @throws TOTPException When creating the username.
+     */
+    private static String getTOTPIssuerDisplayNameForFederatedUser(AuthenticationContext context, String username)
+            throws TOTPException {
+        if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+            String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context, username);
+            if (displayUsernameForFederatedUser != null) {
+                username = displayUsernameForFederatedUser;
+            }
+        }
+        return username;
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -301,9 +301,10 @@ public class TOTPKeyGenerator {
      */
     private static String getTOTPIssuerDisplayNameForFederatedUser(AuthenticationContext context, String username)
             throws TOTPException {
+
         if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
             String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context, username);
-            if (displayUsernameForFederatedUser != null) {
+            if (StringUtils.isNotBlank(displayUsernameForFederatedUser)) {
                 username = displayUsernameForFederatedUser;
             }
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -88,7 +88,9 @@ public class TOTPKeyGenerator {
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
                 String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-                displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
+                if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                    displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
+                }
                 String qrCodeURL =
                         "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                                 issuer + "&period=" + timeStep;
@@ -133,7 +135,9 @@ public class TOTPKeyGenerator {
 
             String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
             String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-            displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
+            if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                displayUsername = getTOTPIssuerDisplayNameForFederatedUser(context, displayUsername);
+            }
             String qrCodeURL =
                     "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
                             issuer + "&period=" + timeStep;
@@ -302,11 +306,9 @@ public class TOTPKeyGenerator {
     private static String getTOTPIssuerDisplayNameForFederatedUser(AuthenticationContext context, String username)
             throws TOTPException {
 
-        if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
-            String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context, username);
-            if (StringUtils.isNotBlank(displayUsernameForFederatedUser)) {
-                username = displayUsernameForFederatedUser;
-            }
+        String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context, username);
+        if (StringUtils.isNotBlank(displayUsernameForFederatedUser)) {
+            username = displayUsernameForFederatedUser;
         }
         return username;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -88,11 +88,8 @@ public class TOTPKeyGenerator {
 
                 String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
                 String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-                if (context.getSubject() != null && context.getSubject().isFederatedUser()) {
-                    String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context);
-                    if (displayUsernameForFederatedUser != null) {
-                        displayUsername = displayUsernameForFederatedUser;
-                    }
+                if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                    displayUsername = TOTPUtil.getTOTOIssuerDisplayNameForFederatedUser(context, displayUsername);
                 }
                 String qrCodeURL =
                         "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +
@@ -138,11 +135,8 @@ public class TOTPKeyGenerator {
 
             String issuer = TOTPUtil.getTOTPIssuerDisplayName(tenantDomain, context);
             String displayUsername = TOTPUtil.getTOTPDisplayUsername(tenantAwareUsername);
-            if (context.getSubject() != null && context.getSubject().isFederatedUser()) {
-                String displayUsernameForFederatedUser = TOTPUtil.createDisplayNameForFederatedUsers(context);
-                if (displayUsernameForFederatedUser != null) {
-                    displayUsername = displayUsernameForFederatedUser;
-                }
+            if (context != null && context.getSubject() != null && context.getSubject().isFederatedUser()) {
+                displayUsername = TOTPUtil.getTOTOIssuerDisplayNameForFederatedUser(context, displayUsername);
             }
             String qrCodeURL =
                     "otpauth://totp/" + issuer + ":" + displayUsername + "?secret=" + secretKey + "&issuer=" +

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -869,11 +869,11 @@ public class TOTPUtil {
     }
 
     /**
-     * Create display name for TOTP in federated Flows
+     * Create display name for TOTP in federated Flows.
      *
      * @param context Authentication context.
      * @return TOTP display name for the federated users.
-     * @throws TOTPException
+     * @throws TOTPException When handling identity provider configurations.
      */
     public static String createDisplayNameForFederatedUsers(AuthenticationContext context)
             throws TOTPException {
@@ -924,9 +924,9 @@ public class TOTPUtil {
      *
      * @param externalIdPConfig External IDP configuration.
      * @param stepConfig        Step configuration.
-     * @param context           Authentication context
+     * @param context           Authentication context.
      * @return Hash map with local claim uri to federated user claim value.
-     * @throws TOTPException
+     * @throws TOTPException When handling claim mappings.
      */
     private static Map<String, String> mapFederateClaimsToLocal(ExternalIdPConfig externalIdPConfig, StepConfig stepConfig,
                                                                 AuthenticationContext context)

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -875,7 +875,7 @@ public class TOTPUtil {
      * @return TOTP display name for the federated users.
      * @throws TOTPException When handling identity provider configurations.
      */
-    private static String createDisplayNameForFederatedUsers(AuthenticationContext context, String username)
+    public static String createDisplayNameForFederatedUsers(AuthenticationContext context, String username)
             throws TOTPException {
 
         SequenceConfig sequenceConfig = context.getSequenceConfig();
@@ -977,24 +977,6 @@ public class TOTPUtil {
             }
         }
         return localClaimValues;
-    }
-
-    /**
-     * Get the display username for federated users.
-     *
-     * @param context  Authentication context.
-     * @param username Username of the authenticated user.
-     * @return Display username for federated users.
-     * @throws TOTPException When creating the username.
-     */
-    public static String getTOTOIssuerDisplayNameForFederatedUser(AuthenticationContext context, String username)
-            throws TOTPException {
-
-        String displayUsernameForFederatedUser = createDisplayNameForFederatedUsers(context, username);
-        if (displayUsernameForFederatedUser != null) {
-            username = displayUsernameForFederatedUser;
-        }
-        return username;
     }
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -910,13 +910,10 @@ public class TOTPUtil {
                                 .getDisplayName();
                         return idpType.concat(":").concat(claimValue);
                     }
-
                 }
             }
-
         }
         return null;
-
     }
 
     /**
@@ -971,9 +968,7 @@ public class TOTPUtil {
                 }
             }
         }
-
         return localClaimValues;
     }
-
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -33,9 +33,13 @@ import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.extension.identity.helper.IdentityHelperConstants;
 import org.wso2.carbon.extension.identity.helper.util.IdentityHelperUtil;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
@@ -44,12 +48,16 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -64,6 +72,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -858,4 +867,113 @@ public class TOTPUtil {
 
         return !new URI(contextFromConfig).isAbsolute();
     }
+
+    /**
+     * Create display name for TOTP in federated Flows
+     *
+     * @param context Authentication context.
+     * @return TOTP display name for the federated users.
+     * @throws TOTPException
+     */
+    public static String createDisplayNameForFederatedUsers(AuthenticationContext context)
+            throws TOTPException {
+
+        SequenceConfig sequenceConfig = context.getSequenceConfig();
+        for (Map.Entry<Integer, StepConfig> entry : sequenceConfig.getStepMap().entrySet()) {
+            StepConfig stepConfig = entry.getValue();
+            AuthenticatorConfig authenticatorConfig = stepConfig.getAuthenticatedAutenticator();
+            ApplicationAuthenticator authenticator = authenticatorConfig.getApplicationAuthenticator();
+
+            if (authenticator instanceof FederatedApplicationAuthenticator) {
+                ExternalIdPConfig externalIdPConfig;
+                String externalIdPConfigName = stepConfig.getAuthenticatedIdP();
+                try {
+                    externalIdPConfig = ConfigurationFacade.getInstance()
+                            .getIdPConfigByName(externalIdPConfigName, context.getTenantDomain());
+                } catch (IdentityProviderManagementException e) {
+                    throw new TOTPException(
+                            "TOTP Display name creation failed!. Error while getting External IDP config.", e);
+                }
+                if (stepConfig != null && stepConfig.isSubjectAttributeStep()) {
+                    if (externalIdPConfig != null) {
+                        Map<String, String> localClaimValues = mapFederateClaimsToLocal(externalIdPConfig, stepConfig, context);
+                        if (localClaimValues.size() == 0 ||
+                                !localClaimValues.containsKey(TOTPAuthenticatorConstants.EMAIL_CLAIM_URL) ||
+                                externalIdPConfig.getIdentityProvider() == null ||
+                                externalIdPConfig.getIdentityProvider().getDefaultAuthenticatorConfig() == null ||
+                                externalIdPConfig.getIdentityProvider().getDefaultAuthenticatorConfig()
+                                        .getDisplayName() == null) {
+                            return null;
+                        }
+                        String claimValue = localClaimValues.get(TOTPAuthenticatorConstants.EMAIL_CLAIM_URL);
+                        String idpType = externalIdPConfig.getIdentityProvider().getDefaultAuthenticatorConfig()
+                                .getDisplayName();
+                        return idpType.concat(":").concat(claimValue);
+                    }
+
+                }
+            }
+
+        }
+        return null;
+
+    }
+
+    /**
+     * Map the federated claims to local claims.
+     *
+     * @param externalIdPConfig External IDP configuration.
+     * @param stepConfig        Step configuration.
+     * @param context           Authentication context
+     * @return Hash map with local claim uri to federated user claim value.
+     * @throws TOTPException
+     */
+    private static Map<String, String> mapFederateClaimsToLocal(ExternalIdPConfig externalIdPConfig, StepConfig stepConfig,
+                                                                AuthenticationContext context)
+            throws TOTPException {
+
+        boolean useDefaultIdpDialect = externalIdPConfig.useDefaultLocalIdpDialect();
+        ApplicationAuthenticator authenticator =
+                stepConfig.getAuthenticatedAutenticator().getApplicationAuthenticator();
+        String idPStandardDialect = authenticator.getClaimDialectURI();
+        Map<ClaimMapping, String> extAttrs = stepConfig.getAuthenticatedUser().getUserAttributes();
+        Map<String, String> originalExternalAttributeValueMap =
+                FrameworkUtils.getClaimMappings(extAttrs, false);
+        Map<String, String> claimMapping;
+        Map<String, String> localClaimValues = new HashMap<>();
+        if (useDefaultIdpDialect && StringUtils.isNotBlank(idPStandardDialect)) {
+            try {
+                claimMapping = ClaimMetadataHandler.getInstance()
+                        .getMappingsMapFromOtherDialectToCarbon(idPStandardDialect,
+                                originalExternalAttributeValueMap.keySet(), context.getTenantDomain(),
+                                true);
+            } catch (ClaimMetadataException e) {
+                throw new TOTPException("TOTP Display name creation failed!. Error while handling claim mappings.", e);
+            }
+        } else {
+            Map<String, String> IDPClaimMapping = new HashMap<>();
+            ClaimMapping[] customClaimMapping = externalIdPConfig.getClaimMappings();
+            for (ClaimMapping externalClaim : customClaimMapping) {
+                if (originalExternalAttributeValueMap.containsKey(externalClaim.getRemoteClaim().getClaimUri())) {
+                    IDPClaimMapping.put(externalClaim.getLocalClaim().getClaimUri(),
+                            externalClaim.getRemoteClaim().getClaimUri());
+                }
+            }
+            claimMapping = IDPClaimMapping;
+        }
+
+        if (claimMapping != null) {
+            for (Map.Entry<String, String> entry : claimMapping.entrySet()) {
+                if (originalExternalAttributeValueMap.containsKey(entry.getValue()) &&
+                        originalExternalAttributeValueMap.get(entry.getValue()) != null) {
+                    localClaimValues.put(entry.getKey(),
+                            originalExternalAttributeValueMap.get(entry.getValue()));
+                }
+            }
+        }
+
+        return localClaimValues;
+    }
+
+
 }


### PR DESCRIPTION
## Purpose
> When TOTP is using with a federated account the identifier of the user that becomes visible in the authenticator app as we scan the QR code is not human readable in some IDPs. This change will display the name in authenticator app in the form `<tenant_name>(<Idp_type>:<email>)`. When no email claim `<tenant_name>(<Idp_type>:<username>)`
