### PR TITLE
Fix TOTP identifier clash issue

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -914,10 +914,9 @@ public class TOTPUtil {
                                     username);
                         }
 
-                        String idpType = externalIdPConfig.getIdentityProvider().getDefaultAuthenticatorConfig()
-                                .getDisplayName();
-                        if (claimValue != null && idpType != null) {
-                            return idpType.concat(":").concat(claimValue);
+                        String idpName = externalIdPConfig.getIdentityProvider().getIdentityProviderName();
+                        if (claimValue != null && idpName != null) {
+                            return idpName.concat(":").concat(claimValue);
                         }
                     }
                 }


### PR DESCRIPTION
## Purpose
> TOTP identifier clashes when there are multiple IdPs in the same type. Therefor this PR will change the TOTP identifier from `<tenant_name>(<Idp_type>:<email>)` to <tenant_name>(<Idp_Name>:<email>) in federated mode.