### PR TITLE
Add totpEnabled Claim

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -35,6 +35,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String AUTHENTICATOR_NAME = "totp";
 	public static final String QR_CODE_CLAIM_URL = "http://wso2.org/claims/identity/qrcodeurl";
 	public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
+	public static final String TOTP_ENABLED_CLAIM_URI = "http://wso2.org/claims/identity/totpEnabled";
 	public static final String VERIFY_SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/verifySecretkey";
 	public static final String ENCODING_CLAIM_URL = "http://wso2.org/claims/identity/encoding";
 	public static final String FIRST_NAME_CLAIM_URL = "http://wso2.org/claims/givenname";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -77,6 +77,7 @@ public class TOTPKeyGenerator {
                     generatedSecretKey = key.getKey();
                     claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
                             TOTPUtil.encrypt(generatedSecretKey));
+                    claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI,"true");
                 } else {
                     decryptedSecretKey = TOTPUtil.decrypt(storedSecretKey);
                 }
@@ -241,6 +242,7 @@ public class TOTPKeyGenerator {
             Map<String, String> claims = new HashMap<>();
             if (userRealm != null) {
                 claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, "");
+                claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI,"false");
                 userRealm.getUserStoreManager()
                         .setUserClaimValues(tenantAwareUsername, claims, null);
                 return true;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -77,7 +77,7 @@ public class TOTPKeyGenerator {
                     generatedSecretKey = key.getKey();
                     claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
                             TOTPUtil.encrypt(generatedSecretKey));
-                    claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI,"true");
+                    claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI, "true");
                 } else {
                     decryptedSecretKey = TOTPUtil.decrypt(storedSecretKey);
                 }
@@ -242,7 +242,7 @@ public class TOTPKeyGenerator {
             Map<String, String> claims = new HashMap<>();
             if (userRealm != null) {
                 claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, "");
-                claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI,"false");
+                claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI, "false");
                 userRealm.getUserStoreManager()
                         .setUserClaimValues(tenantAwareUsername, claims, null);
                 return true;


### PR DESCRIPTION
### Purpose
Add a new claim to ensure that the user has configured a totp authenticator

### Related Issue
- https://github.com/wso2/product-is/issues/12530

### Goals
This allows to improve the UX and the ability for the user to delete the configured TOTP 

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/3731