### PR TITLE
Update TOTP_ENABLED_CLAIM_URI to true in success path

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -380,6 +380,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
                 claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL,
                         context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString());
+                // When secret key is available, have to make TOTP_ENABLED_CLAIM_URI true.
+                claims.put(TOTPAuthenticatorConstants.TOTP_ENABLED_CLAIM_URI, "true");
             }
             if (context.getProperty(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL) != null) {
                 claims.put(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL,


### PR DESCRIPTION
## Purpose
> During a success full authentication flow we need to update the `http://wso2.org/claims/identity/totpEnabled` claim to true.