### PR TITLE
Replace log4j with reload4j

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -69,7 +69,16 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.owasp.encoder</groupId>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -43,9 +43,9 @@
             <version>${identity.extension.utils}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rampart.wso2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <neethi.osgi.version.range>[2.0.4.wso2v4,3.0.0)</neethi.osgi.version.range>
         <libthrift.wso2.version>0.8.0.wso2v1</libthrift.wso2.version>
         <libthrift.wso2.osgi.version.range>[0.8.0.wso2v1,1.0.0)</libthrift.wso2.osgi.version.range>
-        <log4j.version>1.2.13</log4j.version>
+        <reload4j.version>1.2.19</reload4j.version>
         <orbit.version.commons.fileuploader>1.2.0.wso2v1</orbit.version.commons.fileuploader>
         <opensaml.version>2.4.1</opensaml.version>
         <opensaml2.wso2.version>2.4.1.wso2v1</opensaml2.wso2.version>


### PR DESCRIPTION
## Purpose
> Replace log4j dependencies with reload4j in order to mitigate the vulnerabilities reported against log4j