### PR TITLE
Set windowSize,timeStepSize configs on TOTPAdminService

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class is used to initiate, reset the TOTP and refresh the secret key.
@@ -254,18 +255,26 @@ public class TOTPAdminService {
         TOTPKeyRepresentation encoding = TOTPKeyRepresentation.BASE32;
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
         String encodingMethod;
+        long timeStepSize;
+        int windowSize;
         try {
             if (context == null) {
                 encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain);
+                timeStepSize = TOTPUtil.getTimeStepSize(tenantDomain);
+                windowSize = TOTPUtil.getWindowSize(tenantDomain);
             } else {
                 encodingMethod = TOTPUtil.getEncodingMethod(tenantDomain, context);
+                timeStepSize = TOTPUtil.getTimeStepSize(context);
+                windowSize = TOTPUtil.getWindowSize(context);
             }
+            timeStepSize = TimeUnit.SECONDS.toMillis(timeStepSize);
             if (TOTPAuthenticatorConstants.BASE64.equals(encodingMethod)) {
                 encoding = TOTPKeyRepresentation.BASE64;
             }
             TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder configBuilder =
                     new TOTPAuthenticatorConfig.TOTPAuthenticatorConfigBuilder()
-                            .setKeyRepresentation(encoding);
+                            .setKeyRepresentation(encoding)
+                            .setTimeStepSizeInMillis(timeStepSize).setWindowSize(windowSize);
             TOTPAuthenticatorCredentials totpAuthenticator =
                     new TOTPAuthenticatorCredentials(configBuilder.build());
             if (log.isDebugEnabled()) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -452,6 +452,67 @@ public class TOTPUtil {
     }
 
     /**
+     *
+     * @param tenantDomain Tenant Domain
+     * @return Window size of the totp configuration.
+     * @throws AuthenticationFailedException
+     */
+    public static int getWindowSize(String tenantDomain) throws AuthenticationFailedException {
+
+        int windowSize;
+        if (TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN.equals(tenantDomain)) {
+            windowSize = Integer.parseInt(getTOTPParameters().get(TOTPAuthenticatorConstants.WINDOW_SIZE));
+        } else {
+            try {
+                windowSize = getWindowSizeFromRegistry(tenantDomain, null);
+                if (windowSize == -1) {
+                    windowSize = Integer.parseInt(
+                            IdentityHelperUtil.getAuthenticatorParameters(TOTPAuthenticatorConstants.AUTHENTICATOR_NAME)
+                                    .get(TOTPAuthenticatorConstants.WINDOW_SIZE));
+                }
+            } catch (TOTPException e) {
+                throw new AuthenticationFailedException("Cannot find the property value for windowSize", e);
+            }
+        }
+        return windowSize;
+    }
+
+    /**
+     * Get stored window size.
+     *
+     * @param tenantDomain Tenant domain name.
+     * @return Window size.
+     * @throws TOTPException On Error while getting value for window size from registry.
+     */
+    public static int getWindowSizeFromRegistry(String tenantDomain, AuthenticationContext context)
+            throws TOTPException {
+
+        Integer windowSize = null;
+        int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
+        try {
+            NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);
+            windowSize = Integer.parseInt(getAttributeFromRegistry(authConfigList,
+                    TOTPAuthenticatorConstants.WINDOW_SIZE));
+        } catch (RegistryException e) {
+            if (context != null) {
+                context.setProperty(TOTPAuthenticatorConstants.GET_PROPERTY_FROM_IDENTITY_CONFIG,
+                        TOTPAuthenticatorConstants.GET_PROPERTY_FROM_IDENTITY_CONFIG);
+            } else {
+                return -1;
+            }
+        } catch (SAXException e) {
+            throw new TOTPException("Error while parsing the content as XML", e);
+        } catch (ParserConfigurationException e) {
+            throw new TOTPException("Error while creating new Document Builder", e);
+        } catch (IOException e) {
+            throw new TOTPException("Error while parsing the content as XML via ByteArrayInputStream", e);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+        return windowSize;
+    }
+
+    /**
      * Get EnrolUserInAuthenticationFlow.
      *
      * @return true, if EnrolUserInAuthenticationFlow is enabled

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -402,7 +402,7 @@ public class TOTPUtil {
     public static long getTimeStepSizeFromRegistry(String tenantDomain, AuthenticationContext context)
             throws TOTPException {
 
-        Long timeStepSize = null;
+        long timeStepSize = -1;
         int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);
@@ -452,10 +452,11 @@ public class TOTPUtil {
     }
 
     /**
+     * Get stored windows size.
      *
-     * @param tenantDomain Tenant Domain
+     * @param tenantDomain Tenant Domain.
      * @return Window size of the totp configuration.
-     * @throws AuthenticationFailedException
+     * @throws AuthenticationFailedException On Error while getting value for window size from registry.
      */
     public static int getWindowSize(String tenantDomain) throws AuthenticationFailedException {
 
@@ -487,7 +488,7 @@ public class TOTPUtil {
     public static int getWindowSizeFromRegistry(String tenantDomain, AuthenticationContext context)
             throws TOTPException {
 
-        Integer windowSize = null;
+        int windowSize = -1;
         int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
@@ -80,6 +80,8 @@ public class TOTPAdminServiceTest {
         doReturn(userClaimValues).when(mockUserStoreManager).getUserClaimValues(username + "@" + tenantDomain,
                 new String[]{TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
         when(TOTPUtil.decrypt(anyString())).thenReturn(secretKey);
+        when(TOTPUtil.getWindowSize(tenantDomain)).thenReturn(3);
+        when(TOTPUtil.getTimeStepSize(tenantDomain)).thenReturn(30L);
 
         TOTPAdminService totpAdminService = new TOTPAdminService();
         Assert.assertFalse(totpAdminService.validateTOTP(username, null, invalidOTP));


### PR DESCRIPTION
## Purpose
* Fix https://github.com/wso2/product-is/issues/13616
* For admin services, TOTPConfiguration always uses default values for windowSize & timeStepSize configs. With these modifications now it will take the configs values defined in the deployement.toml.
