### PR TITLE
Support JDK 11 and JDK 17 Compilation

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -17,12 +17,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-Welcome to the WSO2 Identity Server (IS) TOTP authenticator.
+## Welcome to the WSO2 Identity Server (IS) TOTP authenticator.
 
 WSO2 IS is one of the best Identity Servers, which enables you to offload your identity and user entitlement management burden totally from your application. It comes with many features, supports many industry standards and most importantly it allows you to extent it according to your security requirements. This repo contains Authenticators written to work with different third party systems. 
 
 With WSO2 IS, there are lot of provisioning capabilities available. There are 3 major concepts as Inbound, outbound provisioning and Just-In-Time provisioning. Inbound provisioning means , provisioning users and groups from an external system to IS. Outbound provisioning means , provisioning users from IS to other external systems. JIT provisioning means , once a user tries to login from an external IDP, a user can be created on the fly in IS with JIT. Repos under this account holds such components invlove in communicating with external systems.
+
+## Building from the source
+
+If you want to build **identity-outbound-auth-totp** from the source code:
+
+1. Install Java 11 (or Java 17)
+2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
+3. Get a clone or download the source from this repository (https://github.com/wso2-extensions/identity-outbound-auth-totp)
+4. Run the Maven command ``mvn clean install`` from the ``identity-outbound-auth-totp`` directory.

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -168,6 +168,13 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/sun.nio.cs=ALL-UNNAMED
+                        --add-opens java.base/java.nio.charset=ALL-UNNAMED
+                        --add-opens java.logging/java.util.logging=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
         <artifactId>identity-outbound-auth-totp</artifactId>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -91,7 +91,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
         FederatedAuthenticatorUtil.class, IdentityUtil.class, ServiceURLBuilder.class, IdentityTenantUtil.class,
         UserSessionStore.class, TOTPDataHolder.class, IdpManager.class, IdentityProvider.class,
         JustInTimeProvisioningConfig.class})
-@PowerMockIgnore({"javax.crypto.*"})
+@PowerMockIgnore({"javax.crypto.*","org.mockito.*","org.powermock.api.mockito.invocation.*"})
 public class TOTPAuthenticatorTest {
 
     private static final String USER_STORE_DOMAIN = "PRIMARY";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -179,6 +179,8 @@ public class TOTPAuthenticatorTest {
         mockStatic(IdentityHelperUtil.class);
         mockStatic(FederatedAuthenticatorUtil.class);
         mockStatic(IdentityUtil.class);
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN)).thenReturn(1);
     }
 
     private void mockServiceURLBuilder() throws URLBuilderException {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGeneratorTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authenticator.totp;
 
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockObjectFactory;
 import org.testng.Assert;
@@ -44,6 +45,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @PrepareForTest({TOTPUtil.class})
+@PowerMockIgnore({"org.mockito.*","org.powermock.api.mockito.invocation.*"})
 public class TOTPKeyGeneratorTest {
 
     @Mock

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
@@ -44,7 +44,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, MultitenantUtils.class, TOTPAuthenticatorCredentials.class})
-@PowerMockIgnore({"javax.crypto.*"})
+@PowerMockIgnore({"javax.crypto.*","org.mockito.*",})
 public class TOTPAdminServiceTest {
 
     @Mock

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtilTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtilTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authenticator.totp.util;
 
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockObjectFactory;
 import org.powermock.reflect.Whitebox;
@@ -62,6 +63,7 @@ import static org.testng.Assert.assertEquals;
 
 @PrepareForTest({FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, ConfigurationFacade.class,
         IdentityTenantUtil.class, ServiceURLBuilder.class})
+@PowerMockIgnore({"org.mockito.*","org.powermock.api.mockito.invocation.*"})
 public class TOTPUtilTest {
 
     private TOTPUtil totpUtil;

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
         <artifactId>identity-outbound-auth-totp</artifactId>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.23.14</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.34</carbon.identity.framework.version>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -342,10 +342,10 @@
         <carbon.identity.event.version.range>[5.13.0, 6.0.0)</carbon.identity.event.version.range>
         <!--Test Dependencies-->
         <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.7.9</jacoco.version>
-        <powermock.version>1.6.5</powermock.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <powermock.version>2.0.9</powermock.version>
         <slf4j.api.version>1.7.12</slf4j.api.version>
-        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
 
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <!--Carbon identity version-->
         <carbon.identity.framework.version>5.23.28</carbon.identity.framework.version>
 
-        <carbon.identity.version>5.23.28</carbon.identity.version>
+        <carbon.identity.version>5.0.8</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <com.fasterxml.jackson.annotation.version>2.5.0</com.fasterxml.jackson.annotation.version>
         <apache.wink.version>1.1.3-incubating</apache.wink.version>
         <openspml.version>192-20100413</openspml.version>
-        <testng.version>6.3.1</testng.version>
+        <testng.version>6.9.10</testng.version>
         <thetransactioncompany.cors-filter.wso2.version>1.7.0.wso2v1</thetransactioncompany.cors-filter.wso2.version>
         <thetransactioncompany.utils.wso2.version>1.9.0.wso2v1</thetransactioncompany.utils.wso2.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.20.34</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.14</carbon.identity.framework.version>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <carbon.kernel.version>4.7.1</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
@@ -139,12 +139,12 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
         <!--Carbon commons version-->
-        <carbon.commons.version>4.4.8</carbon.commons.version>
+        <carbon.commons.version>4.8.7</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.20.34</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.28</carbon.identity.framework.version>
 
-        <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.version>5.23.28</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>
@@ -341,10 +341,10 @@
         <carbon.identity.event.version>5.13.33</carbon.identity.event.version>
         <carbon.identity.event.version.range>[5.13.0, 6.0.0)</carbon.identity.event.version.range>
         <!--Test Dependencies-->
-        <testng.version>6.9.10</testng.version>
+        <testng.version>7.4.0</testng.version>
         <jacoco.version>0.8.7</jacoco.version>
         <powermock.version>2.0.9</powermock.version>
-        <slf4j.api.version>1.7.12</slf4j.api.version>
+        <slf4j.api.version>1.7.21</slf4j.api.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
 
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.totp</groupId>
     <artifactId>identity-outbound-auth-totp</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>WSO2 Carbon Extension - Platform Aggregator Pom</name>
     <url>http://wso2.org</url>
     <parent>


### PR DESCRIPTION
### Purpose

Update the repository to support JDK 11 and JDK 17 compilation.

### When should this PR be merged

After this PR is merged to the main branch, we can't build the branch on JDK 8

### Version checked,

- openjdk "11.0.16.1"
- openjdk "17.0.4.1"

### Related Issue
https://github.com/wso2/product-is/issues/14224