### PR TITLE
[U2] [5.11] Changing failed account lockout and unlock time calculation approach

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -631,8 +631,6 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
 			updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
-			// updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-			// 		String.valueOf(failedLoginLockoutCountValue + 1));
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
 					TOTPAuthenticatorConstants.MAX_TOTP_ATTEMPTS_EXCEEDED);
 			IdentityUtil.threadLocalProperties.get().put(TOTPAuthenticatorConstants.ADMIN_INITIATED, false);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -613,7 +613,9 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		Map<String, String> updatedClaims = new HashMap<>();
 		if ((currentAttempts + 1) >= maxAttempts) {
 			// Calculate the incremental unlock-time-interval in milli seconds.
-			if (context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null) {
+			if (context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null &&
+				context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT)
+						instanceof Integer) {
 				int overallLockoutCount =
 						(int) context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT);
 				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -613,15 +613,26 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		Map<String, String> updatedClaims = new HashMap<>();
 		if ((currentAttempts + 1) >= maxAttempts) {
 			// Calculate the incremental unlock-time-interval in milli seconds.
-			unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-					failedLoginLockoutCountValue));
+			if (context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null) {
+				int overallLockoutCount =
+						(int) context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT);
+				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+						overallLockoutCount));
+				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+						String.valueOf(overallLockoutCount + 1));
+			} else {
+				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+						failedLoginLockoutCountValue));
+				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+						String.valueOf(failedLoginLockoutCountValue + 1));
+			}
 			// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
 			long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
 			updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
-			updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-					String.valueOf(failedLoginLockoutCountValue + 1));
+			// updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+			// 		String.valueOf(failedLoginLockoutCountValue + 1));
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
 					TOTPAuthenticatorConstants.MAX_TOTP_ATTEMPTS_EXCEEDED);
 			IdentityUtil.threadLocalProperties.get().put(TOTPAuthenticatorConstants.ADMIN_INITIATED, false);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -87,4 +87,5 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ADMIN_INITIATED = "AdminInitiated";
 	public static final String ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL = "AllowSendingVerificationCodeByEmail";
 	public static final String MAX_TOTP_ATTEMPTS_EXCEEDED = "MAX_TOTP_ATTEMPTS_EXCEEDED";
+	public static final String OVERALL_FAILED_LOGIN_LOCKOUT_COUNT = "overallFailedLoginLockoutCount";
 }


### PR DESCRIPTION
Changes on calculating unlock time and failed login lockout count using temporary context variable.

Related issue: https://github.com/wso2/product-is/issues/14928

