### PR TITLE
Remove failed login lockout count reset logic

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -613,26 +613,15 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		Map<String, String> updatedClaims = new HashMap<>();
 		if ((currentAttempts + 1) >= maxAttempts) {
 			// Calculate the incremental unlock-time-interval in milli seconds.
-			if (context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null &&
-				context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT)
-						instanceof Integer) {
-				int overallLockoutCount =
-						(int) context.getProperty(TOTPAuthenticatorConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT);
-				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-						overallLockoutCount));
-				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-						String.valueOf(overallLockoutCount + 1));
-			} else {
-				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-						failedLoginLockoutCountValue));
-				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-						String.valueOf(failedLoginLockoutCountValue + 1));
-			}
+			unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+					failedLoginLockoutCountValue));
 			// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
 			long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
 			updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+			updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+					String.valueOf(failedLoginLockoutCountValue + 1));
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
 					TOTPAuthenticatorConstants.MAX_TOTP_ATTEMPTS_EXCEEDED);
 			IdentityUtil.threadLocalProperties.get().put(TOTPAuthenticatorConstants.ADMIN_INITIATED, false);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -664,19 +664,14 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			UserStoreManager userStoreManager = userRealm.getUserStoreManager();
 
 			// Avoid updating the claims if they are already zero.
-			String[] claimsToCheck = {TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM,
-					TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM};
+			String[] claimsToCheck = {TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM};
 			Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
 					UserCoreConstants.DEFAULT_PROFILE);
 			String failedTotpAttempts = userClaims.get(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM);
-			String failedLoginLockoutCount =
-					userClaims.get(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
 
-			if (NumberUtils.isNumber(failedTotpAttempts) && Integer.parseInt(failedTotpAttempts) > 0 ||
-					NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+			if (NumberUtils.isNumber(failedTotpAttempts) && Integer.parseInt(failedTotpAttempts) > 0) {
 				Map<String, String> updatedClaims = new HashMap<>();
 				updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
-				updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
 				userStoreManager
 						.setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
 			}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -87,5 +87,4 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ADMIN_INITIATED = "AdminInitiated";
 	public static final String ENABLE_SEND_VERIFICATION_CODE_BY_EMAIL = "AllowSendingVerificationCodeByEmail";
 	public static final String MAX_TOTP_ATTEMPTS_EXCEEDED = "MAX_TOTP_ATTEMPTS_EXCEEDED";
-	public static final String OVERALL_FAILED_LOGIN_LOCKOUT_COUNT = "overallFailedLoginLockoutCount";
 }


### PR DESCRIPTION
Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/175
This PR has reverted changes related to account locking. PR: https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/137

The failed login lockout count claim reset logic is shifted to a post authentication handler: https://github.com/wso2-support/carbon-identity-framework/pull/2470