### PR TITLE
Improve TOTP enrollment flow to support to enter TOTP in the same page

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -104,6 +104,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
 	public static final String ERROR_CODE = "errorCode";
 	public static final String LOCKED_REASON = "lockedReason";
+	public static final String TOTP_ENROLL_IN_SINGLE_PAGE = "totpEnrollInSinglePage";
 
 	/**
 	 * Enum which contains the error codes and corresponding error messages.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -566,12 +566,36 @@ public class TOTPUtil {
                                                    AuthenticationContext context, String skey)
             throws AuthenticationFailedException {
 
+        redirectToEnableTOTPReqPage(request, response, context, skey, null, null);
+    }
+
+    /**
+     * Redirect the enableTOTP request page.
+     *
+     * @param request    The HttpServletRequest.
+     * @param response   The HttpServletResponse.
+     * @param context    The AuthenticationContext.
+     * @param skey       QR code claim.
+     * @param errorParam Error parameters.
+     * @param retryParam Retry parameters.
+     * @throws AuthenticationFailedException On error while getting value for enrolUserInAuthenticationFlow.
+     */
+    public static void redirectToEnableTOTPReqPage(HttpServletRequest request, HttpServletResponse response,
+                                                   AuthenticationContext context, String skey, String errorParam,
+                                                   String retryParam) throws AuthenticationFailedException {
+
         if (isEnrolUserInAuthenticationFlowEnabled(context)) {
             String multiOptionURI = getMultiOptionURIQueryParam(request);
             String queryParams = "t=" + context.getLoginTenantDomain() + "&sessionDataKey=" +
                     context.getContextIdentifier() + "&authenticators=" + TOTPAuthenticatorConstants.AUTHENTICATOR_NAME
                     + "&type=totp" + "&sp=" + Encode.forUriComponent(context.getServiceProviderName()) +
                     "&ske=" + skey + multiOptionURI;
+            if (StringUtils.isNotBlank(retryParam)) {
+                queryParams += retryParam;
+            }
+            if (StringUtils.isNotBlank(errorParam)) {
+                queryParams += errorParam;
+            }
             String enableTOTPReqPageUrl =
                     FrameworkUtils.appendQueryParamsStringToUrl(getEnableTOTPPage(context), queryParams);
 
@@ -1041,6 +1065,18 @@ public class TOTPUtil {
             }
         }
         return localClaimValues;
+    }
+
+    /**
+     * Check whether TOTP enrollment in single page enabled.
+     *
+     * @return true If TOTP enrollment in single page enabled. Otherwise, return false.
+     */
+    public static boolean isTOTPEnrollInSinglePageEnabled() {
+
+        String isTOTPEnrollInSinglePageEnabled = getTOTPParameters()
+                .getOrDefault(TOTPAuthenticatorConstants.TOTP_ENROLL_IN_SINGLE_PAGE, String.valueOf(false));
+        return Boolean.parseBoolean(isTOTPEnrollInSinglePageEnabled);
     }
 
 }


### PR DESCRIPTION
## Purpose
- Currently, when a user login to a application for the first time, if TOTP is not setup yet, they will required to go through the enrollment flow. In the flow, users need to first scan the QR code and then in the next page validate the code. With this improvement, we are allowing users to validate TOTP in the same page where they scan the code. We introduce a new parameter to keep the backward compatibility. When this parameter is true, the new improvements will be applied.

