### PR TITLE
Sanitizing error messages for diagnostics logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <carbon.commons.version>4.8.7</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.23.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.72</carbon.identity.framework.version>
 
         <carbon.identity.version>5.0.8</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>


### PR DESCRIPTION
## Purpose
> Following diagnostics logs include PII which was added through the error messages of the exceptions thrown. With this PR error messages were sanitized such as when the log masking configuration is enabled, usernames will be masked according to the masking logic.

```
TID: [1542] Tenant: [testasgardeoe2e] [2022-12-19 00:52:14,130] [0vbWfYwAAAADWTzr92mv7Q65kjk/Y6o6BUEhMMzBFREdFMDMxMQAxOWY3NzcyNC04MTJjLTQ0ODYtYTJkMy1iMzQ2MDM4NjhmY2Q=] : iam-cloud-diagnostics :  INFO {org.wso2.carbon.utils.CarbonUtils.publishDiagnosticLog(CarbonUtils.java:1465)} - {""logId"":""eb22feba-0e9a-49be-9587-7b4d05e7a6fe"",""recordedAt"":{""seconds"":1671411134,""nanos"":130136000},""requestId"":""0vbWfYwAAAADWTzr92mv7Q65kjk/Y6o6BUEhMMzBFREdFMDMxMQAxOWY3NzcyNC04MTJjLTQ0ODYtYTJkMy1iMzQ2MDM4NjhmY2Q\u003d"",""resultStatus"":""FAILED"",""resultMessage"":""Authentication failed exception: Invalid Token. Authentication failed, user :  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"",""actionId"":""handle-authentication-step"",""componentId"":""authentication-framework"",""input"":{""tenant domain"":""testasgardeoe2e"",""service provider"":""Single_Page_App_API_06"",""authenticator name"":""totp"",""step"":2}}
```
(masked information manually on the log due to the sensitivity)
