### PR TITLE
Fixing issue with configuring TOTP for federated users

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -718,8 +718,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
     /**
      * Verify whether a given token is valid for the federated user.
      *
-     * @param token        TOTP Token which needs to be validated
-     * @param context      Authentication context
+     * @param token   TOTP Token which needs to be validated
+     * @param context Authentication context
      * @return true if token is valid otherwise false
      * @throws TOTPException If an error occurred while validating token.
      */
@@ -728,12 +728,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
         String secretKey = null;
         if (context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL) != null) {
-            try {
-                secretKey = TOTPUtil.decrypt(context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).
-                        toString());
-            } catch (CryptoException e) {
-                throw new TOTPException("Error while decrypting the secret key", e);
-            }
+            secretKey = context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL).toString();
         }
         TOTPAuthenticatorCredentials totpAuthenticator = getTotpAuthenticator(context, context.getTenantDomain());
         return totpAuthenticator.authorize(secretKey, token);
@@ -893,7 +888,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             UserRealm userRealm = TOTPUtil.getUserRealm(username);
             UserStoreManager userStoreManager = userRealm.getUserStoreManager();
             claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
-                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+                            authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
                             TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM,
                             TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
                     UserCoreConstants.DEFAULT_PROFILE);
@@ -972,7 +967,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             if (idp == null) {
                 throw new AuthenticationFailedException(
                         String.format(
-                        ErrorMessages.ERROR_CODE_INVALID_FEDERATED_AUTHENTICATOR.getMessage(), idpName, tenantDomain));
+                                ErrorMessages.ERROR_CODE_INVALID_FEDERATED_AUTHENTICATOR.getMessage(), idpName, tenantDomain));
             }
             return idp;
         } catch (IdentityProviderManagementException e) {


### PR DESCRIPTION
## Purpose

 Please refer the $subject. 
As we have refactored the TOTP service to remove secret key encryption from TOTP service[1], the decryption of the secret key obtained from the context should also be removed, as the context holds a non-encrypted secret key.

[1] - [https://github.com/wso2-enterprise/asgardeo-product/issues/17280](https://github.com/wso2-enterprise/asgardeo-product/issues/17280)

### Related Issues

- [https://github.com/wso2-enterprise/asgardeo-product/issues/17363](https://github.com/wso2-enterprise/asgardeo-product/issues/17363)
