### PR TITLE
Add diagnostic logs

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
             <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
             <version>${identity.extension.utils}</version>
@@ -122,6 +126,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -144,6 +152,7 @@
                             org.apache.commons.logging.*;version="${commons-logging.osgi.version.range}",
                             org.osgi.framework.*; version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.package.import.version.range}",
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -34,7 +34,9 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
@@ -45,6 +47,7 @@ import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -56,6 +59,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
@@ -63,12 +67,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ErrorMessages;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_TOTP_REQUEST;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.TOTP_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil.getMultiOptionURIQueryParam;
 import static org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil.getTOTPErrorPage;
 import static org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil.getTOTPLoginPage;
@@ -96,7 +105,16 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         String token = request.getParameter(TOTPAuthenticatorConstants.TOKEN);
         String action = request.getParameter(TOTPAuthenticatorConstants.SEND_TOKEN);
         String enableTOTP = request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP);
-        return (token != null || action != null || enableTOTP != null);
+        boolean canHandle = token != null || action != null || enableTOTP != null;
+        if (LoggerUtils.isDiagnosticLogsEnabled() && canHandle) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    TOTP_AUTH_SERVICE, FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_STEP);
+            diagnosticLogBuilder.resultMessage("TOTP Authenticator handling the authentication.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+        return canHandle;
     }
 
     /**
@@ -160,6 +178,16 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                                                  AuthenticationContext context)
             throws AuthenticationFailedException {
 
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    TOTP_AUTH_SERVICE, VALIDATE_TOTP_REQUEST);
+            diagnosticLogBuilder.resultMessage("Validate TOTP authentication request.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
         String username = null;
         Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
         boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(
@@ -202,6 +230,15 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
          */
         boolean isInitialFederationAttempt = StringUtils.isBlank(mappedLocalUsername);
         String loggableUsername = null;
+        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    TOTP_AUTH_SERVICE, VALIDATE_TOTP_REQUEST);
+            diagnosticLogBuilder.logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+        }
 
         try {
             AuthenticatedUser authenticatingUser = resolveAuthenticatingUser(context, authenticatedUserFromContext,
@@ -210,7 +247,13 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             loggableUsername = LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(username) :
                     username;
             context.setProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER, authenticatingUser);
-
+            if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                Map<String, String> userParams = new HashMap<>();
+                userParams.put(LogConstants.InputKeys.USER, loggableUsername);
+                Optional<String> optionalUserId = getUserId(authenticatedUserFromContext);
+                optionalUserId.ifPresent(userId -> userParams.put(LogConstants.InputKeys.USER_ID, userId));
+                diagnosticLogBuilder.inputParams(userParams);
+            }
             String retryParam = "";
             if (context.isRetrying()) {
                 retryParam = "&authFailure=true&authFailureMsg=login.fail.message";
@@ -270,11 +313,21 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                 String totpLoginPageUrl = buildTOTPLoginPageURL(context, username, retryParam,
                         errorParam, multiOptionURI);
                 response.sendRedirect(totpLoginPageUrl);
+                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                    diagnosticLogBuilder.resultMessage("Redirecting to TOTP login page.");
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                }
             } else {
                 Map<String, String> runtimeParams = getRuntimeParams(context);
 
-                if (TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(context, runtimeParams)
-                        && request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP) == null) {
+                boolean enrolUserInAuthenticationFlowEnabled = TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(
+                        context, runtimeParams);
+                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                    diagnosticLogBuilder.inputParam("enroll user in authentication flow enabled",
+                            enrolUserInAuthenticationFlowEnabled);
+                }
+                if (enrolUserInAuthenticationFlowEnabled &&
+                        request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP) == null) {
                     // If TOTP is not enabled for the user and he hasn't redirected to the enrollment page yet.
                     if (log.isDebugEnabled()) {
                         log.debug("User has not enabled TOTP: " + username);
@@ -300,6 +353,10 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                             claims.get(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL));
                     String qrURL = claims.get(TOTPAuthenticatorConstants.QR_CODE_CLAIM_URL);
                     TOTPUtil.redirectToEnableTOTPReqPage(request, response, context, qrURL, runtimeParams);
+                    if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                        diagnosticLogBuilder.resultMessage("Redirecting user to the TOTP enable page.");
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                    }
                 } else if (Boolean.valueOf(request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP)) ||
                         isTOTPEnabledByAdmin) {
                     //if TOTP is not enabled for the user and user continued the enrollment.
@@ -310,6 +367,10 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     String totpLoginPageUrl = buildTOTPLoginPageURL(context, username, retryParam,
                             errorParam, multiOptionURI);
                     response.sendRedirect(totpLoginPageUrl);
+                    if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                        diagnosticLogBuilder.resultMessage("Redirecting to TOTP login page.");
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                    }
                 } else {
                     //if admin does not enforce TOTP and TOTP is not enabled for the user.
                     context.setSubject(authenticatingUser);
@@ -322,6 +383,10 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     } else {
                         context.setProperty(TOTPAuthenticatorConstants.AUTHENTICATION,
                                 TOTPAuthenticatorConstants.FEDERETOR);
+                    }
+                    if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                        diagnosticLogBuilder.resultMessage("TOTP is not enabled for the user.");
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
                     }
                 }
             }
@@ -396,6 +461,16 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                                                  AuthenticationContext context)
             throws AuthenticationFailedException {
 
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    TOTP_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+            diagnosticLogBuilder.resultMessage("Processing TOTP authentication response.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
         String token = request.getParameter(TOTPAuthenticatorConstants.TOKEN);
         AuthenticatedUser authenticatingUser =
                 (AuthenticatedUser) context.getProperty(TOTPAuthenticatorConstants.AUTHENTICATED_USER);
@@ -442,6 +517,19 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         }
         // It reached here means the authentication was successful.
         resetTotpFailedAttempts(context);
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    TOTP_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+            diagnosticLogBuilder.resultMessage("Successfully processed TOTP authentication response.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParam(LogConstants.InputKeys.USER, loggableUsername)
+                    .inputParams(getApplicationDetails(context));
+            Optional<String> optionalUserId = getUserId(context.getSubject());
+            optionalUserId.ifPresent(userId -> diagnosticLogBuilder.inputParam(LogConstants.InputKeys.USER_ID, userId));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
     }
 
     private void checkTotpEnabled(AuthenticationContext context, String username) throws AuthenticationFailedException {
@@ -693,8 +781,13 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                         .getUserStoreManager().getUserClaimValues
                                 (tenantAwareUsername, new String[]
                                         {TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
-                String secretKey = TOTPUtil.decrypt(
-                        userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL));
+                String secretKeyClaim = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+                if (secretKeyClaim == null) {
+                    throw new TOTPException("Secret key claim is null for the user : " +
+                            (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(tenantAwareUsername) :
+                                    tenantAwareUsername));
+                }
+                String secretKey = TOTPUtil.decrypt(secretKeyClaim);
                 return totpAuthenticator.authorize(secretKey, token);
             } else {
                 throw new TOTPException(
@@ -1079,5 +1172,44 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     getProperty(TOTPAuthenticatorConstants.IS_INITIAL_FEDERATED_USER_ATTEMPT).toString());
         }
         return false;
+    }
+
+    /** Add application details to a map.
+     *
+     * @param context AuthenticationContext.
+     * @return Map with application details.
+     */
+    private Map<String, String> getApplicationDetails(AuthenticationContext context) {
+
+        Map<String, String> applicationDetailsMap = new HashMap<>();
+        FrameworkUtils.getApplicationResourceId(context).ifPresent(applicationId ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_ID, applicationId));
+        FrameworkUtils.getApplicationName(context).ifPresent(applicationName ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_NAME,
+                        applicationName));
+        return applicationDetailsMap;
+    }
+
+    /**
+     * Get the user id from the authenticated user.
+     *
+     * @param authenticatedUser AuthenticationContext.
+     * @return User id.
+     */
+    private Optional<String> getUserId(AuthenticatedUser authenticatedUser) {
+
+        if (authenticatedUser == null) {
+            return Optional.empty();
+        }
+        try {
+            if (authenticatedUser.getUserId() != null) {
+                return Optional.ofNullable(authenticatedUser.getUserId());
+            }
+        } catch (UserIdNotFoundException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while getting the user id from the authenticated user.", e);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -69,14 +69,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ErrorMessages;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
-import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_TOTP_REQUEST;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.INITIATE_TOTP_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.TOTP_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil.getMultiOptionURIQueryParam;
 import static org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil.getTOTPErrorPage;
@@ -180,8 +179,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    TOTP_AUTH_SERVICE, VALIDATE_TOTP_REQUEST);
-            diagnosticLogBuilder.resultMessage("Validate TOTP authentication request.")
+                    TOTP_AUTH_SERVICE, INITIATE_TOTP_REQUEST);
+            diagnosticLogBuilder.resultMessage("Initiating TOTP authentication request.")
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
@@ -233,7 +232,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    TOTP_AUTH_SERVICE, VALIDATE_TOTP_REQUEST);
+                    TOTP_AUTH_SERVICE, INITIATE_TOTP_REQUEST);
             diagnosticLogBuilder.logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -323,8 +323,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                 boolean enrolUserInAuthenticationFlowEnabled = TOTPUtil.isEnrolUserInAuthenticationFlowEnabled(
                         context, runtimeParams);
                 if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
-                    diagnosticLogBuilder.inputParam("enroll user in authentication flow enabled",
-                            enrolUserInAuthenticationFlowEnabled);
+                    diagnosticLogBuilder.inputParam("user enrollment enabled", enrolUserInAuthenticationFlowEnabled);
                 }
                 if (enrolUserInAuthenticationFlowEnabled &&
                         request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP) == null) {
@@ -781,13 +780,13 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                         .getUserStoreManager().getUserClaimValues
                                 (tenantAwareUsername, new String[]
                                         {TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
-                String secretKeyClaim = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
-                if (secretKeyClaim == null) {
+                String secretKeyClaimValue = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+                if (secretKeyClaimValue == null) {
                     throw new TOTPException("Secret key claim is null for the user : " +
                             (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(tenantAwareUsername) :
                                     tenantAwareUsername));
                 }
-                String secretKey = TOTPUtil.decrypt(secretKeyClaim);
+                String secretKey = TOTPUtil.decrypt(secretKeyClaimValue);
                 return totpAuthenticator.authorize(secretKey, token);
             } else {
                 throw new TOTPException(
@@ -1174,7 +1173,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         return false;
     }
 
-    /** Add application details to a map.
+    /**
+     * Add application details to a map.
      *
      * @param context AuthenticationContext.
      * @return Map with application details.
@@ -1206,9 +1206,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                 return Optional.ofNullable(authenticatedUser.getUserId());
             }
         } catch (UserIdNotFoundException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while getting the user id from the authenticated user.", e);
-            }
+            log.debug("Error while getting the user id from the authenticated user.", e);
         }
         return Optional.empty();
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -122,7 +122,7 @@ public abstract class TOTPAuthenticatorConstants {
 		public static class ActionIDs {
 
 			public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-totp-authentication-response";
-			public static final String VALIDATE_TOTP_REQUEST = "validate-totp-authentication-request";
+			public static final String INITIATE_TOTP_REQUEST = "initiate-totp-authentication-request";
 		}
 	}
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -110,6 +110,23 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ENABLE_ENCRYPTION = "EnableEncryption";
 
 	/**
+	 * Constants related to log management.
+	 */
+	public static class LogConstants {
+
+		public static final String TOTP_AUTH_SERVICE = "local-auth-totp";
+
+		/**
+		 * Define action IDs for diagnostic logs.
+		 */
+		public static class ActionIDs {
+
+			public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-totp-authentication-response";
+			public static final String VALIDATE_TOTP_REQUEST = "validate-totp-authentication-request";
+		}
+	}
+
+	/**
 	 * Enum which contains the error codes and corresponding error messages.
 	 */
 	public enum ErrorMessages {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
-import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
@@ -53,6 +52,7 @@ import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPData
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -92,7 +92,7 @@ import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthen
         FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, CarbonContext.class,
         FederatedAuthenticatorUtil.class, IdentityUtil.class, ServiceURLBuilder.class, IdentityTenantUtil.class,
         UserSessionStore.class, TOTPDataHolder.class, IdpManager.class, IdentityProvider.class,
-        JustInTimeProvisioningConfig.class})
+        JustInTimeProvisioningConfig.class, LoggerUtils.class})
 @PowerMockIgnore({"javax.crypto.*","org.mockito.*","org.powermock.api.mockito.invocation.*"})
 public class TOTPAuthenticatorTest {
 
@@ -186,6 +186,8 @@ public class TOTPAuthenticatorTest {
         mockStatic(IdentityUtil.class);
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN)).thenReturn(1);
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
     }
 
     private void mockServiceURLBuilder() throws URLBuilderException {
@@ -557,6 +559,7 @@ public class TOTPAuthenticatorTest {
         authenticatedUser.setFederatedUser(true);
         authenticatedUser.setUserName(username);
         authenticatedUser.setFederatedIdPName("Google");
+        authenticatedUser.setUserId("dummyUserId");
         when(mockedContext.getTenantDomain()).thenReturn(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
 
         when(TOTPUtil.isLocalUser(mockedContext)).thenReturn(false);

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${carbon.identity.account.lock.handler.version}</version>
@@ -90,6 +95,12 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
@@ -136,7 +147,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.kernel.version>4.9.9</carbon.kernel.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
@@ -147,7 +158,10 @@
         <carbon.commons.version>4.8.7</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
 
         <carbon.identity.version>5.0.8</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
-                <scope>provided</scope>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>


### PR DESCRIPTION
## Purpose
* Add diagnostic logs

### Approach

![image](https://github.com/wso2-enterprise/asgardeo-product/assets/32576163/ceea5959-581e-47aa-b7b2-6962861a2b2d)

Diagnostic logs will be covered the green-colored actions/validations of the authentication process. 
1. Authentication Request Validation
Within each authenticator, the `initiateAuthenticationRequest` method houses the logic for this step. This triggers two diagnostic logs. The first log indicates when authentication validation starts, and the second log shows the result of the validation – whether it's a Success or marked Invalid.

2. Validate Authentication Response
The `processAuthenticationResponse` method handles authentication response validation. Once users are sent to the authentication page and complete the process, the authenticator receives an authentication response, which this method manages. Just like the request validation, this step also generates two diagnostic logs. The first one marks the beginning of response validation, while the second one is only created if the authentication is successful. We've chosen not to include logs for authentication response failures for a couple of reasons:
- Numerous potential failure scenarios across authenticators make adding logs for each too complicated and code-heavy.
- With https://github.com/wso2/carbon-identity-framework/pull/4809, there's a common log in place that covers and reports authentication response failures caused by authenticators.

Additionally, there will be another diagnostic log that will get published from the canHandle() method of the authenticator. The `canHandle` method gets executed each time before the `initiateAuthenticationRequest` and `processAuthenticationResponse` get executed. This log is published as an internal log for our internal developers. The purpose of this log is to verify whether the auth request/response was passed into the authenticator to handle it.