### PR TITLE
Add unlock-time url parameter when locked user

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -74,6 +74,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.ErrorMessages;
+import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LOGIN_FAIL_MESSAGE;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.ActionIDs.INITIATE_TOTP_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants.LogConstants.TOTP_AUTH_SERVICE;
@@ -196,6 +197,11 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
             showAuthFailureReasonOnLoginPage = Boolean.parseBoolean(parameterMap.get(
                     TOTPAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE));
         }
+        // Auth failure message if account is locked.
+        String accLockAuthFailureMsg = parameterMap.get(TOTPAuthenticatorConstants.CONF_ACC_LOCK_AUTH_FAILURE_MSG);
+        if (StringUtils.isEmpty(accLockAuthFailureMsg)) {
+            accLockAuthFailureMsg = LOGIN_FAIL_MESSAGE;
+        }
 
         AuthenticatedUser authenticatedUserFromContext = TOTPUtil.getAuthenticatedUser(context);
         if (authenticatedUserFromContext == null) {
@@ -275,6 +281,10 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     }
                     // Only adds error code if it is locked error code.
                     if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
+                        // Change auth failure message if the error code is locked.
+                        if (context.isRetrying()) {
+                            retryParam = "&authFailure=true&authFailureMsg=" + accLockAuthFailureMsg;
+                        }
                         Map<String, String> paramMap = new HashMap<>();
                         paramMap.put(TOTPAuthenticatorConstants.ERROR_CODE, errorCode);
                         if (StringUtils.isNotBlank(reason)) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -199,7 +199,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         }
         // Auth failure message if account is locked.
         String accLockAuthFailureMsg = parameterMap.get(TOTPAuthenticatorConstants.CONF_ACC_LOCK_AUTH_FAILURE_MSG);
-        if (StringUtils.isEmpty(accLockAuthFailureMsg)) {
+        if (StringUtils.isBlank(accLockAuthFailureMsg)) {
             accLockAuthFailureMsg = LOGIN_FAIL_MESSAGE;
         }
 
@@ -280,7 +280,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                         }
                     }
                     // Only adds error code if it is locked error code.
-                    if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
+                    if (UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(errorCode)) {
                         // Change auth failure message if the error code is locked.
                         if (context.isRetrying()) {
                             retryParam = "&authFailure=true&authFailureMsg=" + accLockAuthFailureMsg;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -89,6 +89,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
 	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+	public static final String LOGIN_FAIL_MESSAGE = "login.fail.message";
 	public static final String ADMIN_INITIATED = "AdminInitiated";
 	public static final String FEDERATED_USERNAME = "FederatedUsername";
 
@@ -102,6 +103,7 @@ public abstract class TOTPAuthenticatorConstants {
 
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
+	public static final String CONF_ACC_LOCK_AUTH_FAILURE_MSG = "accLockAuthFailureMessage";
 	public static final String ERROR_CODE = "errorCode";
 	public static final String UNLOCK_TIME = "unlockTime";
 	public static final String LOCKED_REASON = "lockedReason";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -103,6 +103,7 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
 	public static final String ERROR_CODE = "errorCode";
+	public static final String UNLOCK_TIME = "unlockTime";
 	public static final String LOCKED_REASON = "lockedReason";
 
 	// This constant has been defined in FrameworkConstants class in framework repo as well. Hence, when changing this

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -103,7 +103,7 @@ public abstract class TOTPAuthenticatorConstants {
 
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
 	public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
-	public static final String CONF_ACC_LOCK_AUTH_FAILURE_MSG = "accLockAuthFailureMessage";
+	public static final String CONF_ACC_LOCK_AUTH_FAILURE_MSG = "accountLockAuthFailureMessage";
 	public static final String ERROR_CODE = "errorCode";
 	public static final String UNLOCK_TIME = "unlockTime";
 	public static final String LOCKED_REASON = "lockedReason";


### PR DESCRIPTION
When a user is locked following parameters are added to the URL if `showAuthFailureReason` is enabled
```
errorCode: 17003
lockedReason: MAX_TOTP_ATTEMPTS_EXCEEDED
unlockTime: <unlockTime>
authFailure: true
authFailureMsg: <authFailureMessage>
```

Auth failure message when account is locked can be changes by adding following config
```
[authentication.authenticator.totp.parameters]
accountLockAuthFailureMessage = "user.account.locked"
```

Related issue https://github.com/wso2/product-is/issues/16333