### PR TITLE
[5.11.0] Fix the issue of account locking behaviour in TOTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -842,9 +842,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
 		if (isIndefiniteLock(unlockTimePropertyValue)) {
 			return 0;
-		} else {
-			return calculateLockoutDuration(unlockTimePropertyValue, unlockTimeRatio, failedLoginLockoutCountValue);
 		}
+		return calculateLockoutDuration(unlockTimePropertyValue, unlockTimeRatio, failedLoginLockoutCountValue);
 	}
 
 	private boolean isIndefiniteLock(long unlockTimePropertyValue) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -715,14 +715,16 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
 		Map<String, String> updatedClaims = new HashMap<>();
 		if ((currentAttempts + 1) >= maxAttempts) {
-			// Calculate the incremental unlock-time-interval in milli seconds.
-			unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-					failedLoginLockoutCountValue));
-			// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
-			long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+			// Calculate the incremental unlock-time-interval in milli seconds if the unlock-time is not equal to 0.
+			if(unlockTimePropertyValue != 0) {
+				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+						failedLoginLockoutCountValue));
+				// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
+				long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+				updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+			}
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
 			updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
-			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
 			updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
 					String.valueOf(failedLoginLockoutCountValue + 1));
 			updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -848,6 +848,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 	}
 
 	private boolean isIndefiniteLock(long unlockTimePropertyValue) {
+
 		return TOTPUtil.isIndefiniteAccountLockingEnabled() && unlockTimePropertyValue == 0;
 	}
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -716,7 +716,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 		Map<String, String> updatedClaims = new HashMap<>();
 		if ((currentAttempts + 1) >= maxAttempts) {
 			// Calculate the incremental unlock-time-interval in milli seconds if the unlock-time is not equal to 0.
-			if(unlockTimePropertyValue != 0) {
+			if (unlockTimePropertyValue != 0) {
 				unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
 						failedLoginLockoutCountValue));
 				// Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -80,6 +80,8 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String AUTHENTICATED_USER = "authenticatedUser";
 	public static final String LOCAL_AUTHENTICATOR = "LOCAL";
 	public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+	public static final String ENABLE_INDEFINITE_ACCOUNT_LOCKING_FOR_DURATAION_ZERO
+			= "EnableIndefiniteAccountLockingForDurationZero";
 	public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -753,6 +753,17 @@ public class TOTPUtil {
     }
 
     /**
+     * Check whether indefinite account locking is enabled for TOTP when account lock duraion is 0.
+     *
+     * @return True if indefinite account locking is enabled for TOTP when account lock duraion is 0.
+     */
+    public static boolean isIndefinteAccountLockingIsEnabled() {
+
+        return Boolean.parseBoolean(
+                getTOTPParameters().get(TOTPAuthenticatorConstants.ENABLE_INDEFINITE_ACCOUNT_LOCKING_FOR_DURATAION_ZERO));
+    }
+
+    /**
      * Check whether the user account is locked.
      *
      * @param userName        The username of the user.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -757,7 +757,7 @@ public class TOTPUtil {
      *
      * @return True if indefinite account locking is enabled for TOTP when account lock duraion is 0.
      */
-    public static boolean isIndefinteAccountLockingIsEnabled() {
+    public static boolean isIndefiniteAccountLockingEnabled() {
 
         return Boolean.parseBoolean(
                 getTOTPParameters().get(TOTPAuthenticatorConstants.ENABLE_INDEFINITE_ACCOUNT_LOCKING_FOR_DURATAION_ZERO));


### PR DESCRIPTION
## Purpose
- Fix the issue with account lock behavior when set `Initial Account Lock Duration` to 0
- With this fix, we are introducing the below config to enable this fix.
```

[authentication.authenticator.totp.parameters]
EnableIndefiniteAccountLockingForDurationZero  = true


```
- If you set the above configuration to true and `Initial Account Lock Durataion` = 0 , with the fix, account will be locked after max failed attempts until admin user unlock.

## Related issue
https://github.com/wso2/product-is/issues/21219