### PR TITLE
Support the feature of indefinitely lock the user until the admin unlocks

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -1033,14 +1033,16 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
         Map<String, String> updatedClaims = new HashMap<>();
         if ((currentAttempts + 1) >= maxAttempts) {
-            // Calculate the incremental unlock-time-interval in milli seconds.
-            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-                    failedLoginLockoutCountValue));
-            // Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
-            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+            if (unlockTimePropertyValue != 0) {
+                // Calculate the incremental unlock-time-interval in milli seconds.
+                unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+                        failedLoginLockoutCountValue));
+                // Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
+                long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+                updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+            }
             updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
             updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
-            updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
             updatedClaims.put(TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
                     String.valueOf(failedLoginLockoutCountValue + 1));
             updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,


### PR DESCRIPTION
## Purpose
- Support the feature of indefinitely lock the user until the admin unlocks the user account when the `initial lock duration` is set to 0.

## Related issue
https://github.com/wso2/product-is/issues/21219

## Related PR
UI PR : https://github.com/wso2/identity-apps/pull/6997