### PR TITLE
[5.11.0] Fix the 'Verification failed. Please try again.' error when registering a TOTP Authenticator

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPKeyGenerator.java
@@ -99,7 +99,7 @@ public class TOTPKeyGenerator {
                 if (StringUtils.isEmpty(storedSecretKey) || refresh) {
                     TOTPAuthenticatorKey key = generateKey(tenantDomain, context);
                     generatedSecretKey = key.getKey().getBytes();
-                    claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, TOTPUtil.encrypt(generatedSecretKey));
+                    claims.put(secretKeyClaim, TOTPUtil.encrypt(generatedSecretKey));
                     secretKey = ArrayUtils.isNotEmpty(generatedSecretKey) ? generatedSecretKey : new byte[0];
                 } else {
                     byte[] decryptedSecret = TOTPUtil.decryptSecret(storedSecretKey);


### PR DESCRIPTION
## Purpose
> Fix an issue where when registering the TOTP Authenticator in the MyAccount application, a prompt to enter the TOTP is displayed after scanning the QR code for verification. However upon entering the TOTP a "Verification failed. Please try again." error message appears.

## Implementation
Updated the generateClaims() method to set the secret key claim using the secretKeyClaim parameter instead of the constant. Previously, the method was using:

`claims.put(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL, TOTPUtil.encrypt(generatedSecretKey));`

This has been updated to:

`claims.put(secretKeyClaim, TOTPUtil.encrypt(generatedSecretKey));`

The method is invoked in multiple places with different secretKeyClaim values. Using the constant within the method causes incorrect behavior, as it ignores the provided parameter.

## Related issue
- https://github.com/wso2/product-is/issues/21575