### PR TITLE
[5.11.0] Add the SP parameter for TOTP redirection URLs

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -226,7 +226,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 			String totpErrorPageUrl =
 					getErrorPage(context) + ("?sessionDataKey=" + context.getContextIdentifier()) +
 							"&authenticators=" + getName() + "&type=totp_error" + retryParam +
-							"&username=" + username + errorParam + multiOptionURI;
+							"&username=" + username + "&sp="
+							+ Encode.forUriComponent(context.getServiceProviderName()) + errorParam + multiOptionURI;
 			if (isTOTPEnabled && request.getParameter(TOTPAuthenticatorConstants.ENABLE_TOTP) == null) {
 				//if TOTP is enabled for the user.
 				if (!showAuthFailureReasonOnLoginPage) {
@@ -329,7 +330,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
 
 		return getLoginPage(context) + ("?sessionDataKey=" + context.getContextIdentifier()) +
 				"&authenticators=" + getName() + "&type=totp" + retryParam + "&username=" +
-				username + errorParam + multiOptionURI;
+				username + "&sp="
+				+ Encode.forUriComponent(context.getServiceProviderName()) + errorParam + multiOptionURI;
 	}
 
 	/**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -564,7 +564,8 @@ public class TOTPUtil {
                     ("?sessionDataKey=" + context.getContextIdentifier()) +
                     "&authenticators=" +
                     TOTPAuthenticatorConstants.AUTHENTICATOR_NAME +
-                    "&type=totp" + "&ske=" + skey + multiOptionURI;
+                    "&type=totp" + "&sp=" + Encode.forUriComponent(context.getServiceProviderName()) +
+                    "&ske=" + skey + multiOptionURI;
             try {
                 response.sendRedirect(enableTOTPReqPageUrl);
             } catch (IOException e) {


### PR DESCRIPTION
## Purpose
Currently, the `SP` parameter is not forwarded from the authentication request within the TOTP connector. This PR addresses this gap by providing out of the box support for forwarding the `SP` parameter in the authentication request. This will enable users to be redirected to the appropriate service provider specific branding during TOTP scenarios, improving the overall user experience for customers utilizing SP specific branding.

The following scenarios are affected and tested:

1. **TOTP QR Code Scan Page** - When a user has not configured TOTP yet.
    <img width="460" alt="Screenshot 2024-12-19 at 10 22 21 AM" src="https://github.com/user-attachments/assets/23172009-b4f3-40a0-bce0-f4c57d9be6ab" />

2. **TOTP Code Request Page** - When the user is prompted to enter the TOTP code.
    <img width="460" alt="Screenshot 2024-12-19 at 10 23 04 AM" src="https://github.com/user-attachments/assets/91f5bc78-4618-4281-be0e-e8b4966bf176" />

3. **TOTP Error Page** - In case of an error during the TOTP authentication flow.
    <img width="460" alt="Screenshot 2024-12-19 at 10 23 20 AM" src="https://github.com/user-attachments/assets/8201dc74-893a-467b-a212-a1473f59012e" />

## Related Issues
- https://github.com/wso2/product-is/issues/22045