### PR TITLE
Unlock user after successfully authenticate with the TOTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -1107,12 +1107,14 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     UserCoreConstants.DEFAULT_PROFILE);
             String failedTotpAttempts = userClaims.get(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM);
 
+            Map<String, String> updatedClaims = new HashMap<>();
+            updatedClaims.put(TOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+
             if (NumberUtils.isNumber(failedTotpAttempts) && Integer.parseInt(failedTotpAttempts) > 0) {
-                Map<String, String> updatedClaims = new HashMap<>();
                 updatedClaims.put(TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM, "0");
-                userStoreManager
-                        .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
             }
+            userStoreManager
+                    .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
         } catch (UserStoreException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error while resetting failed TOTP attempts count for user: " + username, e);


### PR DESCRIPTION
## Purpose

#### The existing logic.

After exceeding the maximum fail attempts, the account get locked and set the failed TOTP attempt count to zero [1]. After the defined account lock time exceeds, it allows to attempt TOTP, then start from failed TOTP attempt count zero.

When initiating correct TOTP, after few TOTP failed attempts before account lock, the failed TOTP count should be reset to zero. 

#### Improvement.

- When try to reset TOTP failures after a successful attempt, we should update the lock status as unlock (irrespective of checking  failed TOTP count is zero or more, the account lock claim should be updated in this case).

[1] - https://github.com/wso2-extensions/identity-outbound-auth-totp/blob/master/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java#L1045

### Related Issues
- https://github.com/wso2/product-is/issues/22288