### PR TITLE
Improve TOTP authenticator to skip locking account when account lock is disabled

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -984,6 +984,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                         authenticatedUser.getUserStoreDomain())) {
             return;
         }
+        boolean accountLockOnFailedAttemptsEnabled = false;
         int maxAttempts = 0;
         long unlockTimePropertyValue = 0;
         double unlockTimeRatio = 1;
@@ -992,9 +993,8 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         for (Property connectorConfig : connectorConfigs) {
             switch (connectorConfig.getName()) {
                 case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
-                    if (!Boolean.parseBoolean(connectorConfig.getValue())) {
-                        return;
-                    }
+                    accountLockOnFailedAttemptsEnabled = Boolean.parseBoolean(connectorConfig.getValue());
+                    break;
                 case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
                     if (NumberUtils.isNumber(connectorConfig.getValue())) {
                         maxAttempts = Integer.parseInt(connectorConfig.getValue());
@@ -1015,6 +1015,11 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
                     break;
             }
         }
+
+        if (!accountLockOnFailedAttemptsEnabled) {
+            return;
+        }
+
         Map<String, String> claimValues = getUserClaimValues(authenticatedUser, new String[]{
                 TOTPAuthenticatorConstants.TOTP_FAILED_ATTEMPTS_CLAIM,
                 TOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM});


### PR DESCRIPTION
## Purpose

When account locking is disabled, there is no governance connector config whether account lock on failed login is enabled or disabled (The config exists only if enabled). Due to that existing logic fails to detect the account locking is disabled.

> The issue doesn't exist for a fresh setup where the account lock on failed login is not yet enabled. The issue arises after enabling and, then again disabling the account lock on failed login.

Under above mentioned state, there can be scenarios TOTP authenticator is being used as second factor with account lock happens even it was not configured by the Administrator. 

The Administrator must intentionally disable account locking on failed attempts for the situation mentioned above. Correcting the buggy behavior can be done without requiring any notification.

#### Related Issues
- https://github.com/wso2/product-is/issues/22288