### PR TITLE
Fix the account lock enable constant being incorrectly defined

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticator.java
@@ -993,6 +993,7 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         for (Property connectorConfig : connectorConfigs) {
             switch (connectorConfig.getName()) {
                 case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_ENABLE:
                     accountLockOnFailedAttemptsEnabled = Boolean.parseBoolean(connectorConfig.getValue());
                     break;
                 case TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
@@ -1094,7 +1095,9 @@ public class TOTPAuthenticator extends AbstractApplicationAuthenticator
         // Return if account lock handler is not enabled.
         for (Property connectorConfig : connectorConfigs) {
             if ((TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
-                    !Boolean.parseBoolean(connectorConfig.getValue())) {
+                    !Boolean.parseBoolean(connectorConfig.getValue()) ||
+                    (TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_ENABLE
+                            .equals(connectorConfig.getName())) && !Boolean.parseBoolean(connectorConfig.getValue())) {
                 return;
             }
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorConstants.java
@@ -92,6 +92,8 @@ public abstract class TOTPAuthenticatorConstants {
 	public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
 	public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_ENABLE =
+			"account.lock.handler.lock.on.max.failed.attempts.enable";
 	public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
 	public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
 	public static final String LOGIN_FAIL_MESSAGE = "login.fail.message";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -890,6 +890,7 @@ public class TOTPUtil {
                     .getConfiguration(
                             new String[]{
                                     TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE,
+                                    TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_ENABLE,
                                     TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX,
                                     TOTPAuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_TIME,
                                     TOTPAuthenticatorConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO


### PR DESCRIPTION
## Purpose
> $subject

The previous constant has an outdated value for identifying the account lock on max failed attempt feature is enabled or not.