### PR TITLE
Fix TOTP issuer logic when registry throws exception

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/util/TOTPUtil.java
@@ -265,8 +265,8 @@ public class TOTPUtil {
             NodeList authConfigList = getAuthenticationConfigNodeList(tenantDomain, tenantID);
             issuer = getAttributeFromRegistry(authConfigList, TOTPAuthenticatorConstants.TOTP_ISSUER);
         } catch (RegistryException e) {
-            //Default to tenant domain name on registry exception.
-            issuer = tenantDomain;
+            // Default to null on registry exception.
+            issuer = null;
         } catch (SAXException e) {
             throw new TOTPException("Error while parsing the content as XML", e);
         } catch (ParserConfigurationException e) {


### PR DESCRIPTION
### Purpose

When the TOTP issuer is resolved from the registry and if the registry method throws an exception, issuer was set as the tenant domain. But we have added further logic to set tenant domain or organization name for suborganizations. But this improving logic is not reached, because with the exception, issuer is set to the tenant domain.

This PR fixes it by not setting the issuer after a registry exception is caught.

### Related Issues
- https://github.com/wso2/product-is/issues/19830