### PR TITLE
Add logic to resolve TOTP key from context

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPTokenGenerator.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authenticator.totp;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
@@ -105,8 +106,11 @@ public class TOTPTokenGenerator {
 							userRealm.getUserStoreManager().getUserClaimValues
 									(tenantAwareUsername, new String[] {
 											TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL }, null);
-					String secretKey = TOTPUtil.decrypt(
-							userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL));
+					String secretKeyValue = userClaimValues.get(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+					if (StringUtils.isBlank(secretKeyValue)) {
+						secretKeyValue = (String) context.getProperty(TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL);
+					}
+					String secretKey = TOTPUtil.decrypt(secretKeyValue);
 					String firstName = userRealm
 							.getUserStoreManager().getUserClaimValue
 									(tenantAwareUsername,


### PR DESCRIPTION
## Purpose
When TOTP enrolment is performed, and within the same authentication flow, the user clicks the "Get a Verification Code" button, the authenticator tries to retrieve the secret key from the `http://wso2.org/claims/identity/secretkey` claim from the userstore. 

However, during TOTP enrolment during the login flow, eventhough a secret key is generated, it is not yet stored under the `http://wso2.org/claims/identity/secretkey` claim, as user is not authenticated yet. As a result, when the authenticator tries to retrieve the value, it gets null, leading to the NPE.

Related issues
- https://github.com/wso2/product-is/issues/24130