### PR TITLE
[IS 5.9.0]Improve the authorization of the operations

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminService.java
@@ -20,19 +20,24 @@ package org.wso2.carbon.identity.application.authenticator.totp.services;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPKeyGenerator;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
+import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorConfig;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorCredentials;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorKey;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPKeyRepresentation;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
@@ -46,6 +51,9 @@ import java.util.Map;
 public class TOTPAdminService {
 
     private static final Log log = LogFactory.getLog(TOTPAdminService.class);
+    private static final String DEFAULT_USER_UPDATE_PERMISSION = "/permission/admin/manage/identity/usermgt/update";
+    private static final String SELF_OPERATIONS_ENABLED = "AdminServices.TOTPAdminService.SelfOperations.Enabled";
+    private static final String SERVICE_PERMISSION = "AdminServices.TOTPAdminService.Permission";
 
     /**
      * Generate TOTP Token for a given user.
@@ -57,6 +65,10 @@ public class TOTPAdminService {
      */
     public String initTOTP(String username, AuthenticationContext context) throws TOTPException {
 
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
         Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false, context);
         return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
     }
@@ -70,9 +82,13 @@ public class TOTPAdminService {
      */
     public String generateSecret(String username) throws TOTPException {
 
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
+
         Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, false);
 
-        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         try {
             UserRealm userRealm = TOTPUtil.getUserRealm(username);
             if (userRealm != null) {
@@ -110,6 +126,10 @@ public class TOTPAdminService {
     public boolean enableTOTP(String username, int verificationCode) throws TOTPException {
 
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
+
         try {
             UserRealm userRealm = TOTPUtil.getUserRealm(username);
             if (userRealm != null) {
@@ -163,6 +183,11 @@ public class TOTPAdminService {
      */
     public boolean resetTOTP(String username) throws TOTPException, AuthenticationFailedException {
 
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
+
         return TOTPKeyGenerator.resetLocal(username);
     }
 
@@ -175,6 +200,11 @@ public class TOTPAdminService {
      * @throws TOTPException when could not find the user
      */
     public String refreshSecretKey(String username, AuthenticationContext context) throws TOTPException {
+
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
 
         Map<String, String> claims = TOTPKeyGenerator.generateClaims(username, true, context);
         return TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims, username, context);
@@ -199,6 +229,9 @@ public class TOTPAdminService {
             userRealm = TOTPUtil.getUserRealm(username);
             String tenantDomain = MultitenantUtils.getTenantDomain(username);
             tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+            if (!this.isAuthorized(tenantAwareUsername)) {
+                throw new TOTPException("User is not authorized perform the operation");
+            }
             if (userRealm != null) {
                 Map<String, String> userClaimValues = userRealm.getUserStoreManager().
                         getUserClaimValues(tenantAwareUsername,
@@ -243,6 +276,11 @@ public class TOTPAdminService {
     public boolean validateTOTP(String username, AuthenticationContext context, int verificationCode) throws
             TOTPException {
 
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        if (!this.isAuthorized(tenantAwareUsername)) {
+            throw new TOTPException("User is not authorized perform the operation");
+        }
+
         String secretKey = retrieveSecretKey(username, context);
 
         return validateTOTP(username, verificationCode, secretKey, context);
@@ -275,5 +313,55 @@ public class TOTPAdminService {
         } catch (AuthenticationFailedException e) {
             throw new TOTPException("TOTPTokenVerifier cannot find the property value for encodingMethod.", e);
         }
+    }
+
+    /**
+     * Check whether the authenticated user is authorized to perform the operation on the target user.
+     * Authorization is successful if the authenticated user is trying to perform the operation on his own or
+     * has the required permission.
+     *
+     * @param targetUser       user on whom the operation is being performed
+     * @return true if authorized, false otherwise
+     * @throws TOTPException when error occurs while checking authorization
+     */
+    private boolean isAuthorized(String targetUser) throws TOTPException {
+
+        String authenticatedUsername = CarbonContext.getThreadLocalCarbonContext().getUsername();
+        int authenticatedTenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
+        RealmService realmService = TOTPDataHolder.getInstance().getRealmService();
+        try {
+            UserRealm userRealm = realmService.getTenantUserRealm(authenticatedTenantId);
+            return isUserAuthorizedToPerformOperation(userRealm, authenticatedUsername, targetUser);
+        } catch (UserStoreException e) {
+            throw new TOTPException("Error while checking the authorization to perform the operation.", e);
+        }
+    }
+
+    private static boolean isUserAuthorizedToPerformOperation(UserRealm realm, String currentUserName,
+                                                              String targetUser)
+            throws UserStoreException {
+
+        String selfOperationsEnabled = (String) IdentityConfigParser.getInstance().getConfiguration().
+                get(SELF_OPERATIONS_ENABLED);
+        String permission = (String) IdentityConfigParser.getInstance().getConfiguration().
+                get(SERVICE_PERMISSION);
+
+        if (Boolean.parseBoolean(selfOperationsEnabled)) {
+            if (StringUtils.equals(currentUserName, targetUser)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Self operations are enabled. Hence user: " + currentUserName +
+                            " is authorized to perform the operation on himself.");
+                }
+                return true;
+            }
+        }
+        if (StringUtils.isEmpty(permission)) {
+            permission = DEFAULT_USER_UPDATE_PERMISSION;
+            if (log.isDebugEnabled()) {
+                log.debug("Permission is not configured. Hence using the default permission: " + permission);
+            }
+        }
+        AuthorizationManager authorizer = realm.getAuthorizationManager();
+        return authorizer.isUserAuthorized(currentUserName, permission, "ui.execute");
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.application.authenticator.totp.services;
 
 import org.junit.Assert;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,12 +27,19 @@ import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPTokenGenerator;
+import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorCredentials;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
@@ -39,11 +47,13 @@ import java.util.Map;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, MultitenantUtils.class, TOTPAuthenticatorCredentials.class})
+@PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, MultitenantUtils.class, TOTPAuthenticatorCredentials.class
+        , IdentityConfigParser.class, CarbonContext.class})
 @PowerMockIgnore({"javax.crypto.*"})
 public class TOTPAdminServiceTest {
 
@@ -56,10 +66,14 @@ public class TOTPAdminServiceTest {
     @BeforeMethod
     public void setUp() {
 
+        repareCarbonHome();
+
         initMocks(this);
         mockStatic(TOTPUtil.class);
         mockStatic(TOTPTokenGenerator.class);
         mockStatic(MultitenantUtils.class);
+        mockStatic(IdentityConfigParser.class);
+        mockStatic(CarbonContext.class);
     }
 
     @Test(description = "test ValidateTOTP() method for invalid verification code.")
@@ -81,8 +95,39 @@ public class TOTPAdminServiceTest {
                 new String[]{TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
         when(TOTPUtil.decrypt(anyString())).thenReturn(secretKey);
 
+        IdentityConfigParser identityConfigParser = mock(IdentityConfigParser.class);
+        when(IdentityConfigParser.getInstance()).thenReturn(identityConfigParser);
+        Map<String,Object> configMap = new HashMap<>();
+        configMap.put("AdminServices.TOTPAdminService.SelfOperations.Enabled", "false");
+        configMap.put("AdminServices.TOTPAdminService.Permission",
+                "/permission/admin/manage/identity/usermgt/update");
+        when(identityConfigParser.getConfiguration()).thenReturn(configMap);
+
+        mockRealm();
+
         TOTPAdminService totpAdminService = new TOTPAdminService();
         Assert.assertFalse(totpAdminService.validateTOTP(username, null, invalidOTP));
+    }
+
+    private void mockRealm() throws UserStoreException {
+
+        CarbonContext mockCarbonContext = mock(CarbonContext.class);
+        when(CarbonContext.getThreadLocalCarbonContext()).thenReturn(mockCarbonContext);
+        when(mockCarbonContext.getUsername()).thenReturn("admin");
+        when(mockCarbonContext.getTenantId()).thenReturn(-1234);
+        RealmService realmService = mock(RealmService.class);
+        TOTPDataHolder.getInstance().setRealmService(realmService);
+        when(realmService.getTenantUserRealm(Matchers.anyInt())).thenReturn(mockUserRealm);
+        AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
+        when(mockUserRealm.getAuthorizationManager()).thenReturn(authorizationManager);
+        when(authorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(true);
+    }
+
+    private void repareCarbonHome() {
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, this.getClass().getResource("/").getFile());
+        System.setProperty("carbon.protocol", "https");
+        System.setProperty("carbon.host", "localhost");
+        System.setProperty("carbon.management.port", "9443");
     }
 
     @ObjectFactory


### PR DESCRIPTION
porting: https://github.com/wso2-support/identity-outbound-auth-totp/pull/37
issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/4490

Add this inside the already existing `AdminServices` tag in the identity.xml.j2 file

```
<TOTPAdminService>
      <SelfOperations>
          <Enabled>{{totp_admin_service.self_operations.enabled | default('false')}}</Enabled>
      </SelfOperations>
      <Permission>{{totp_admin_service.permission | default('/permission/admin/manage/identity/usermgt/update')}}</Permission>
</TOTPAdminService>
```

Add below in the deployment.toml as required
```
[totp_admin_service]
self_operations.enabled = true
permission="/permission/admin/manage/identity/usermgt/update"
```