### PR TITLE
Improve the authorization of the operations 

### DIFF
--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/TOTPAuthenticatorTest.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.L
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authenticator.totp.exception.TOTPException;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -67,10 +68,12 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, ConfigurationFacade.class, TOTPTokenGenerator.class,
-        FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, CarbonContext.class,
+        FileBasedConfigurationBuilder.class, IdentityHelperUtil.class, CarbonContext.class, IdentityUtil.class,
         FederatedAuthenticatorUtil.class})
 @PowerMockIgnore({"javax.crypto.*" })
 public class TOTPAuthenticatorTest {
+
+    private static final String USER_STORE_DOMAIN = "PRIMARY";
 
     @Mock
     private TOTPAuthenticator mockedTOTPAuthenticator;
@@ -322,7 +325,10 @@ public class TOTPAuthenticatorTest {
 
     @Test(description = "Test case for initiateAuthenticationRequest() method with totp enabled user.")
     public void testInitiateAuthenticationRequest() throws AuthenticationFailedException, UserStoreException {
+
         String username = "admin";
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
         AuthenticatedUser authenticatedUser = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username);
         AuthenticationContext authenticationContext = new AuthenticationContext();
         authenticationContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
@@ -347,7 +353,10 @@ public class TOTPAuthenticatorTest {
             "TOTP is not enabled for the user.")
     public void testInitiateAuthenticationRequestWithEnrollment() throws AuthenticationFailedException,
             UserStoreException {
+
         String username = "admin";
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
         AuthenticatedUser authenticatedUser = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username);
         mockedContext.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
         mockedContext.setProperty("username", username);
@@ -374,7 +383,10 @@ public class TOTPAuthenticatorTest {
     @Test(description = "Test case for initiateAuthenticationRequest() method when admin enforces TOTP and " +
             "TOTP is not enabled for the user.", priority=2)
     public void testInitiateAuthenticationRequestAdminEnforces() throws AuthenticationFailedException, UserStoreException, IOException {
+
         String username = "admin";
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
         AuthenticatedUser authenticatedUser = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username);
         context.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
         context.setProperty("username", username);
@@ -403,7 +415,10 @@ public class TOTPAuthenticatorTest {
     @Test(description = "Test case for initiateAuthenticationRequest() method when admin enforces TOTP and " +
             "TOTP is not enabled for the user.", priority=2)
     public void testInitiateAuthenticationWithEnableTOTP() throws AuthenticationFailedException, UserStoreException, IOException {
+
         String username = "admin";
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn(USER_STORE_DOMAIN);
         AuthenticatedUser authenticatedUser = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username);
         context.setTenantDomain(TOTPAuthenticatorConstants.SUPER_TENANT_DOMAIN);
         context.setProperty("username", username);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/totp/services/TOTPAdminServiceTest.java
@@ -26,24 +26,34 @@ import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.totp.TOTPTokenGenerator;
+import org.wso2.carbon.identity.application.authenticator.totp.internal.TOTPDataHolder;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPAuthenticatorCredentials;
 import org.wso2.carbon.identity.application.authenticator.totp.util.TOTPUtil;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, MultitenantUtils.class, TOTPAuthenticatorCredentials.class})
+@PrepareForTest({TOTPUtil.class, TOTPTokenGenerator.class, MultitenantUtils.class, TOTPAuthenticatorCredentials.class
+        , IdentityConfigParser.class, CarbonContext.class})
 @PowerMockIgnore({"javax.crypto.*"})
 public class TOTPAdminServiceTest {
 
@@ -56,10 +66,14 @@ public class TOTPAdminServiceTest {
     @BeforeMethod
     public void setUp() {
 
+        repareCarbonHome();
+
         initMocks(this);
         mockStatic(TOTPUtil.class);
         mockStatic(TOTPTokenGenerator.class);
         mockStatic(MultitenantUtils.class);
+        mockStatic(IdentityConfigParser.class);
+        mockStatic(CarbonContext.class);
     }
 
     @Test(description = "test ValidateTOTP() method for invalid verification code.")
@@ -81,12 +95,45 @@ public class TOTPAdminServiceTest {
                 new String[]{TOTPAuthenticatorConstants.SECRET_KEY_CLAIM_URL}, null);
         when(TOTPUtil.decrypt(anyString())).thenReturn(secretKey);
 
+        IdentityConfigParser identityConfigParser = mock(IdentityConfigParser.class);
+        when(IdentityConfigParser.getInstance()).thenReturn(identityConfigParser);
+        Map<String,Object> configMap = new HashMap<>();
+        configMap.put("AdminServices.TOTPAdminService.SelfOperations.Enabled", "false");
+        configMap.put("AdminServices.TOTPAdminService.Permission",
+                "/permission/admin/manage/identity/usermgt/update");
+        when(identityConfigParser.getConfiguration()).thenReturn(configMap);
+
+        mockRealm();
+
         TOTPAdminService totpAdminService = new TOTPAdminService();
         Assert.assertFalse(totpAdminService.validateTOTP(username, null, invalidOTP));
     }
 
+    private void mockRealm() throws UserStoreException {
+
+        CarbonContext mockCarbonContext = mock(CarbonContext.class);
+        when(CarbonContext.getThreadLocalCarbonContext()).thenReturn(mockCarbonContext);
+        when(mockCarbonContext.getUsername()).thenReturn("admin");
+        when(mockCarbonContext.getTenantId()).thenReturn(-1234);
+        RealmService realmService = mock(RealmService.class);
+        TOTPDataHolder.getInstance().setRealmService(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(mockUserRealm);
+        AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
+        when(mockUserRealm.getAuthorizationManager()).thenReturn(authorizationManager);
+        when(authorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(true);
+    }
+
+    private void repareCarbonHome() {
+
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, this.getClass().getResource("/").getFile());
+        System.setProperty("carbon.protocol", "https");
+        System.setProperty("carbon.host", "localhost");
+        System.setProperty("carbon.management.port", "9443");
+    }
+
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
+
         return new PowerMockObjectFactory();
     }
 }


### PR DESCRIPTION
Add this inside the already existing AdminServices tag in the identity.xml.j2 file

```
<TOTPAdminService>
      <SelfOperations>
          <Enabled>{{totp_admin_service.self_operations.enaled | default('false')}}</Enabled>
      </SelfOperations>
      <Permission>{{totp_admin_service.permission | default('/permission/admin/manage/identity/usermgt/update')}}</Permission>
</TOTPAdminService>
```

Add below in the deployment.toml as required

```
[totp_admin_service]
self_operations.enaled = true
permission="/permission/admin/manage/identity/usermgt/update"
```